### PR TITLE
Replace == version with >= version

### DIFF
--- a/src/base/compiler.hh
+++ b/src/base/compiler.hh
@@ -90,7 +90,7 @@
 namespace m5
 {
 
-#if __cplusplus == 201402L // C++14
+#if __cplusplus >= 201402L // C++14
 
 using std::make_unique;
 
@@ -106,7 +106,7 @@ make_unique( Args&&... constructor_args )
            );
 }
 
-#endif // __cplusplus == 201402L
+#endif // __cplusplus >= 201402L
 
 } //namespace m5
 


### PR DESCRIPTION
For forward compatibility with later compilers, we should have a greater
than comparison instead of an explicit equality with a particular C++
version.