### PR TITLE
flexcpu: Add stats for special instructions

### DIFF
--- a/src/cpu/flexcpu/simple_dataflow_thread.cc
+++ b/src/cpu/flexcpu/simple_dataflow_thread.cc
@@ -903,6 +903,7 @@ SDCPUThread::populateDependencies(shared_ptr<InflightInst> inst_ptr)
             DPRINTF(SDCPUDeps, "Dep %d -> %d [serial]\n",
                     inst_ptr->seqNum(), serializing_inst->seqNum());
             inst_ptr->addCommitDependency(serializing_inst);
+            waitingForSerializing++;
         }
 
         if (inflightInsts.size() > 1 && static_inst->isSerializing()) {
@@ -915,6 +916,7 @@ SDCPUThread::populateDependencies(shared_ptr<InflightInst> inst_ptr)
                 DPRINTF(SDCPUDeps, "Dep %d -> %d [serial]\n",
                         inst_ptr->seqNum(), last_inst->seqNum());
                 inst_ptr->addCommitDependency(last_inst);
+                serializingInst++;
             }
 
             lastSerializingInstruction = inst_ptr;
@@ -927,6 +929,7 @@ SDCPUThread::populateDependencies(shared_ptr<InflightInst> inst_ptr)
             DPRINTF(SDCPUDeps, "Dep %d -> %d [serial]\n",
                     inst_ptr->seqNum(), last_inst->seqNum());
             inst_ptr->addCommitDependency(last_inst);
+            serializingInst++;
         }
 
         auto serializing_inst = lastSerializingInstruction.lock();
@@ -934,10 +937,12 @@ SDCPUThread::populateDependencies(shared_ptr<InflightInst> inst_ptr)
             DPRINTF(SDCPUDeps, "Dep %d -> %d [serial]\n",
                     inst_ptr->seqNum(), serializing_inst->seqNum());
             inst_ptr->addCommitDependency(serializing_inst);
+            waitingForSerializing++;
         }
 
         if (static_inst->isSerializeAfter()) {
             lastSerializingInstruction = inst_ptr;
+            serializingInst++;
         }
     }
 
@@ -954,11 +959,13 @@ SDCPUThread::populateDependencies(shared_ptr<InflightInst> inst_ptr)
             DPRINTF(SDCPUDeps, "Dep %d -> %d [mem ref -> barrier]\n",
                     inst_ptr->seqNum(), last_barrier->seqNum());
             inst_ptr->addMemDependency(last_barrier);
+            waitingForMemBarrier++;
         }
     }
 
     if (static_inst->isMemBarrier()) {
         lastMemBarrier = inst_ptr;
+        memBarrier++;
         for (auto itr = inflightInsts.rbegin();
              itr != inflightInsts.rend();
              ++itr) {
@@ -973,8 +980,10 @@ SDCPUThread::populateDependencies(shared_ptr<InflightInst> inst_ptr)
                         inst_ptr->seqNum(), (*itr)->seqNum());
                 if (static_inst->isMemRef()) {
                     inst_ptr->addMemDependency(*itr);
+                    waitingForMemBarrier++;
                 } else {
                     inst_ptr->addDependency(*itr);
+                    waitingForMemBarrier++;
                 }
             }
         }
@@ -993,6 +1002,7 @@ SDCPUThread::populateDependencies(shared_ptr<InflightInst> inst_ptr)
 
         if (!(last_inst->isCommitted() || last_inst->isSquashed())) {
             inst_ptr->addCommitDependency(last_inst);
+            nonSpeculativeInst++;
         }
 
         // This is a very conservative implementation of the rule, but has been
@@ -1525,6 +1535,27 @@ SDCPUThread::regStats(const std::string &name)
         .init(32)
         .desc("Number of instructions active each cycle")
     ;
+
+    serializingInst
+        .name(name + ".serializingInst")
+        .desc("Number of serializing instructions added to inflight insts.")
+        ;
+    waitingForSerializing
+        .name(name + ".waitingForSerializing")
+        .desc("Number of instructions that had to wait a serializing inst")
+        ;
+    waitingForMemBarrier
+        .name(name + ".waitingForMemBarrier")
+        .desc("Number of instructions that had to wait for a memory barrier")
+        ;
+    memBarrier
+        .name(name + ".memBarrier")
+        .desc("Number of memory barriers")
+        ;
+    nonSpeculativeInst
+        .name(name + ".nonSpeculativeInst")
+        .desc("Number of non speculative instructions")
+        ;
 
     instTypes
         .name(name + ".instTypes")

--- a/src/cpu/flexcpu/simple_dataflow_thread.hh
+++ b/src/cpu/flexcpu/simple_dataflow_thread.hh
@@ -564,6 +564,12 @@ class SDCPUThread : public ThreadContext
     Stats::Histogram squashedPerCycle;
     Stats::Histogram activeInstructions;
 
+    Stats::Scalar serializingInst;
+    Stats::Scalar waitingForSerializing;
+    Stats::Scalar waitingForMemBarrier;
+    Stats::Scalar memBarrier;
+    Stats::Scalar nonSpeculativeInst;
+
     // END Statistics
 
   public:


### PR DESCRIPTION
This adds stats for serializing instructions, memory barriers, and non
speculative instructions and their impact on other instructions added to
the inflight instructions list.

Change-Id: I989f15dfc30a4d3acd1efd661b40915ad46ec926
Signed-off-by: Jason Lowe-Power <jason@lowepower.com>