### PR TITLE
arch-x86: [hack!!] Fix bug in O3

### DIFF
--- a/src/arch/isa_parser.py
+++ b/src/arch/isa_parser.py
@@ -2210,7 +2210,7 @@ StaticInstPtr
         # just wrap the decoding code from the block as a case in the
         # outer switch statement.
         codeObj.wrap_decode_block('\n%s\n' % ''.join(case_list),
-                                  'M5_UNREACHABLE;\n')
+                                  'return new Unknown(machInst); break;\n')
         codeObj.has_decode_default = (case_list == ['default:'])
         t[0] = codeObj
 


### PR DESCRIPTION
When compiled with optimizations, there's cases when the O3 is trying to
decode illegal instructions (e.g., when the front end is running far
ahead) that causes a segfault in the decoder. I believe there's a case
where we say M5_UNREACHABLE when this is *not* true. If we instead emit
some reasonable code the segfault goes away.

Change-Id: I58ffea5b5eba57a6a08dd158cbff3ed8b5f5b17f