### PR TITLE
scons: add -Wno-unused-const-variable flag

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -351,7 +351,8 @@ if main['GCC'] or main['CLANG']:
     # Enable -Wall and -Wextra and then disable the few warnings that
     # we consistently violate
     main.Append(CCFLAGS=['-Wall', '-Wundef', '-Wextra',
-                         '-Wno-sign-compare', '-Wno-unused-parameter'])
+                         '-Wno-sign-compare', '-Wno-unused-parameter',
+                         '-Wno-unused-const-variable'])
     # We always compile using C++11
     main.Append(CXXFLAGS=['-std=c++11'])
     if sys.platform.startswith('freebsd'):


### PR DESCRIPTION
Clang generates errors on unused constant variables, which are created from .cc files that are compiled from .py files. The flag '-Wno-unused-const-variable' is set to suppress those errors.