### PR TITLE
cpu-flex: Remove redundant list for branches past prediction limit

### DIFF
--- a/src/cpu/flexcpu/simple_dataflow_thread.hh
+++ b/src/cpu/flexcpu/simple_dataflow_thread.hh
@@ -259,10 +259,10 @@ class SDCPUThread : public ThreadContext
      */
     unsigned remainingBranchPredDepth;
     /**
-     * A queue for control instructions exceeding the above limit to wait for
-     * either execution or prediction.
+     * The branch which could not be predicted as a result of hitting the
+     * maximum branch prediction depth constraint.
      */
-    std::list<std::weak_ptr<InflightInst>> unpredictedBranches;
+    std::weak_ptr<InflightInst> unpredictedBranch;
 
 
     // END Speculative state


### PR DESCRIPTION
Change-Id: I641f1ece58ddc4ea7fe20206d0b45f20a41c2e5d
Signed-off-by: Bradley Wang <radwang@ucdavis.edu>