### PR TITLE
cpu-flex: delete control block pointers in squashed split edge case

### DIFF
--- a/src/cpu/flexcpu/simple_dataflow_cpu.cc
+++ b/src/cpu/flexcpu/simple_dataflow_cpu.cc
@@ -117,6 +117,16 @@ SimpleDataflowCPU::completeMemAccess(PacketPtr orig_pkt, StaticInstPtr inst,
             panic("Malformed split MemAccessReq received!");
         }
 
+        // If the other half of the request was killed somehow, we need to
+        // clean up to avoid memory leaks. Only one of the conditions here will
+        // be true, because the other one will match orig_pkt, and be deleted
+        // via the recvTimingResp() function.
+        if (!split->low || !split->high) {
+            delete split->main;
+            delete split;
+            return;
+        }
+
         if (!(split->lowReceived && split->highReceived))
             return; // We need to wait for the other to complete as well
 
@@ -592,7 +602,7 @@ SimpleDataflowCPU::requestSplitMemRead(const RequestPtr& main,
             // No need to send req if squashed
             delete split_acc->low;
             split_acc->low = nullptr;
-            if (!split_acc->high) {
+            if (!split_acc->high || split_acc->highReceived) {
                 delete split_acc->main;
                 delete split_acc;
             }
@@ -629,7 +639,7 @@ SimpleDataflowCPU::requestSplitMemRead(const RequestPtr& main,
             // No need to send req if squashed
             delete split_acc->high;
             split_acc->high = nullptr;
-            if (!split_acc->low) {
+            if (!split_acc->low || split_acc->lowReceived) {
                 delete split_acc->main;
                 delete split_acc;
             }
@@ -714,7 +724,7 @@ SimpleDataflowCPU::requestSplitMemWrite(const RequestPtr& main,
             // No need to send req if squashed
             delete split_acc->low;
             split_acc->low = nullptr;
-            if (!split_acc->high) {
+            if (!split_acc->high || split_acc->highReceived) {
                 delete split_acc->main;
                 delete split_acc;
             }
@@ -755,7 +765,7 @@ SimpleDataflowCPU::requestSplitMemWrite(const RequestPtr& main,
             // No need to send req if squashed
             delete split_acc->high;
             split_acc->high = nullptr;
-            if (!split_acc->low) {
+            if (!split_acc->low || split_acc->lowReceived) {
                 delete split_acc->main;
                 delete split_acc;
             }


### PR DESCRIPTION
Change-Id: I62a1171a0e7f252a6ff153793c9e7cf0f3fcaed4
Signed-off-by: Bradley Wang <radwang@ucdavis.edu>