### PR TITLE
scons: fix disable_partial logic for fast binary

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -1376,9 +1376,9 @@ if 'opt' in needed_envs:
 
 # "Fast" binary
 if 'fast' in needed_envs:
-    disable_partial = disable_partial and \
-            env.get('BROKEN_INCREMENTAL_LTO', False) and \
-            GetOption('force_lto')
+    disable_partial = disable_partial or \
+            (env.get('BROKEN_INCREMENTAL_LTO', False) and \
+            GetOption('force_lto'))
     makeEnv(env, 'fast', '.fo', strip = True,
             CCFLAGS = Split(ccflags['fast']),
             CPPDEFINES = ['NDEBUG', 'TRACING_ON=0'],


### PR DESCRIPTION
Partial linking should be disabled on darwin; however, the script
fails to do so when force_lto is set, which results in gem5 building
with fast option fails on macOS. This fix changes disable_partial
logic, which should be True once it's True.