### PR TITLE
cpu-flex: Added Branch Prediction functionality to FlexCPU

### DIFF
--- a/src/cpu/flexcpu/FlexCPU.py
+++ b/src/cpu/flexcpu/FlexCPU.py
@@ -28,12 +28,22 @@
 
 
 from BaseCPU import BaseCPU
+from BranchPredictor import *
 from m5.params import *
 from m5.proxy import *
 
 class FlexCPU(BaseCPU):
     type = 'FlexCPU'
     cxx_header = 'cpu/flexcpu/flexcpu.hh'
+
+    # formatted camelCase to use same parameter name as other CPU models.
+    branchPred = Param.BranchPredictor(TournamentBP(
+        numThreads = Parent.numThreads), "Branch predictor")
+    branch_pred_max_depth = Param.Unsigned(20,
+                                           "How many branches deep the "
+                                           "predictor is allowed to explore "
+                                           "at any given point in time. Set "
+                                           "to 0 for infinite.")
 
     execution_latency = Param.Cycles(1, "Number of cycles for each "
                                          "instruction to execute")

--- a/src/cpu/flexcpu/SConscript
+++ b/src/cpu/flexcpu/SConscript
@@ -43,9 +43,10 @@ if 'FlexCPU' in env['CPU_MODELS']:
     DebugFlag('FlexCPUInstEvent')
     DebugFlag('FlexCPUThreadEvent')
 
+    DebugFlag('FlexCPUBranchPred')
     DebugFlag('FlexCPUBufferDump')
     DebugFlag('FlexCPUDeps')
 
     CompoundFlag('FlexCPUAll', ['FlexCPUCoreEvent', 'FlexCPUInstEvent',
-                              'FlexCPUThreadEvent',
+                              'FlexCPUThreadEvent', 'FlexCPUBranchPred',
                               'FlexCPUBufferDump', 'FlexCPUDeps'])

--- a/src/cpu/flexcpu/flexcpu.cc
+++ b/src/cpu/flexcpu/flexcpu.cc
@@ -359,16 +359,34 @@ FlexCPU::requestMemRead(const RequestPtr& req, ThreadContext* tc,
 
     PacketPtr pkt = Packet::createRead(req);
     pkt->allocate();
+    // Note: pkt is deleted in DataPort::recvTimingResp(), except in the case
+    //       of mmappedIpr where it is deleted in the internally scheduled
+    //       event.
 
-    // Note: pkt is deleted in DataPort::recvTimingResp();
-
+    // Despite mmappedIpr accessing registers, we do not explicitly check any
+    // register dependencies under the assumption that the misc regs will not
+    // be accessed through other means, and that memory dependence resolution
+    // will be sufficient to ensure correct out-of-order behavior.
     if (req->isMmappedIpr()) {
-        // TODO think about limiting access to mmapped IPR
-        panic("FlexCPU not programmed to understand mmapped IPR!");
-        // Cycles delay = TheISA::handleIprRead(tc, pkt);
-        // TODO create an event delay cycles later that calls completeAcc() on
-        //      the StaticInst.
-        return false;
+        // TODO think about limiting access to mmapped IPR, either alongside
+        //      other memory requests, or as its own constraint
+
+        Tick now = curTick();
+        Tick delay(cyclesToTicks(TheISA::handleIprRead(tc, pkt)));
+
+        schedule(
+            new EventFunctionWrapper(
+                [this, pkt, inst, context, trace_data, callback_func, now]
+                {
+                    completeMemAccess(pkt, inst, context, trace_data,
+                                      callback_func, now);
+                    delete pkt;
+                },
+                name() + ".mmappedIprEvent",
+                true),
+            now + delay);
+
+        return true;
     }
 
     Tick queue_time = curTick();
@@ -424,7 +442,9 @@ FlexCPU::requestMemWrite(const RequestPtr& req, ThreadContext* tc,
     }
 
     PacketPtr pkt = Packet::createWrite(req);
-    // Note: pkt is deleted in DataPort::recvTimingResp();
+    // Note: pkt is deleted in DataPort::recvTimingResp(), except in the case
+    //       of mmappedIpr where it is deleted in the internally scheduled
+    //       event.
 
     if (data) {
         const unsigned req_size = req->getSize();
@@ -440,12 +460,25 @@ FlexCPU::requestMemWrite(const RequestPtr& req, ThreadContext* tc,
     }
 
     if (req->isMmappedIpr()) {
-        // TODO think about limiting access to mmapped IPR
-        panic("FlexCPU not programmed to understand mmapped IPR!");
-        // Cycles delay = TheISA::handleIprWrite(tc, pkt);
-        // TODO create an event delay cycles later that calls completeAcc() on
-        //      the StaticInst.
-        return false;
+        // TODO think about limiting access to mmapped IPR, either alongside
+        //      other memory requests, or as its own constraint
+
+        Tick now = curTick();
+        Tick delay(cyclesToTicks(TheISA::handleIprWrite(tc, pkt)));
+
+        schedule(
+            new EventFunctionWrapper(
+                [this, pkt, inst, context, trace_data, callback_func, now]
+                {
+                    completeMemAccess(pkt, inst, context, trace_data,
+                                      callback_func, now);
+                    delete pkt;
+                },
+                name() + ".mmappedIprEvent",
+                true),
+            now + delay);
+
+        return true;
     }
 
     Tick queue_time = curTick();
@@ -504,6 +537,9 @@ FlexCPU::requestSplitMemRead(const RequestPtr& main,
         return false; // TODO figure out if this is even possible on split
                       //      requests?
     }
+
+    panic_if(main->isMmappedIpr(), "SDCPU does not yet support split "
+                                   "mmappedIpr.");
 
     SplitAccCtrlBlk* split_acc = new SplitAccCtrlBlk;
 
@@ -611,6 +647,9 @@ FlexCPU::requestSplitMemWrite(const RequestPtr& main,
         return false; // TODO figure out if this is even possible on split
                       //      requests?
     }
+
+    panic_if(main->isMmappedIpr(), "SDCPU does not yet support split "
+                                   "mmappedIpr.");
 
     SplitAccCtrlBlk* split_acc = new SplitAccCtrlBlk;
 

--- a/src/cpu/flexcpu/flexcpu.hh
+++ b/src/cpu/flexcpu/flexcpu.hh
@@ -38,6 +38,7 @@
 
 #include "cpu/base.hh"
 #include "cpu/flexcpu/flexcpu_thread.hh"
+#include "cpu/pred/bpred_unit.hh"
 #include "mem/packet.hh"
 #include "params/FlexCPU.hh"
 
@@ -313,6 +314,14 @@ class FlexCPU : public BaseCPU
     DataPort _dataPort;
     InstPort _instPort;
 
+    /**
+     * Branch predictor object pointer. One should be selected by the python
+     * configuration and assigned via parameter. Currently each CPU will only
+     * hold one, which will be shared across all threads requesting access to
+     * it.
+     */
+    BPredUnit* _branchPred;
+
     // Using unique_ptr for now since holding objects directly results
     // in calls to the object's copy constructor, which SimpleThread does not
     // like.
@@ -390,6 +399,15 @@ class FlexCPU : public BaseCPU
     void haltContext(ThreadID tid) override;
 
     /**
+     * Non-event-driven way to access the branch predictor. Should only be used
+     * to notify the branch predictor of instructions being squashed or
+     * committed.
+     *
+     * @return BPredUnit* The branch predictor owned by the CPU.
+     */
+    BPredUnit* getBranchPredictor();
+
+    /**
      * Interface calls to retrieve a reference to the port used for data or
      * instructions respectively.
      */
@@ -397,10 +415,30 @@ class FlexCPU : public BaseCPU
     MasterPort& getInstPort() override;
 
     /**
+     * Checks if the CPU was configured with a branch predictor.
+     *
+     * @return true Has a non-NULL branch predictor
+     * @return false Has no non-NULL branch predictor
+     */
+    bool hasBranchPredictor() const;
+
+    /**
      * Called after constructor but before running. (Make sure to call
      * BaseCPU::init() in this function to let it do its job)
      */
     void init() override;
+
+    /**
+     * Event-driven way to request access to the branch predictor unit held by
+     * the CPU. Callback should be expected to be on the same tick, unless
+     * access to the branch predictor is constrained via prediction time or
+     * number of ports.
+     *
+     * @param callback_func the callback through which the predictor will be
+     *  provided.
+     */
+    void requestBranchPredictor(
+        std::function<void(BPredUnit* pred)> callback_func);
 
     /**
      * Event-driven means for classes to request a translation of a particular


### PR DESCRIPTION
cpu-flex: Added Branch Prediction functionality (auxiliary changes removed from 569966e)

Signed-off-by: Bradley Wang <radwang@ucdavis.edu>

flexcpu: Modify BP to not fetch if it's wrong

Instead of trying to fetch more instructions when we *know* the branch
predictor is wrong, simply stop the fetch unit. This will improve the
performance of the simulator (from 408s to 103s for Bubblesort). This
slightly changes the simulated system's performance, but by much less
that 1% for Bubblesort, and it's unclear if this change is anything
except random noise.

Signed-off-by: Jason Lowe-Power <jason@lowepower.com>

flexcpu: Add stats (with bp stats, original 2a390ba)

Add stats for branch predictor mis-prediction latency and
the number of instructions fetched incorrectly

Signed-off-by: Jason Lowe-Power <jason@lowepower.com>

cpu-flex: fixed case where bpd was not released if buffer full

Signed-off-by: Bradley Wang <radwang@ucdavis.edu>

cpu-flex: Remove redundant list for branches past prediction limit

Change-Id: I355410665e3047119b1358391eade084bc5b453e
Signed-off-by: Bradley Wang <radwang@ucdavis.edu>