### PR TITLE
cpu-flex: Added some necessary code for fullsystem

### DIFF
--- a/src/cpu/flexcpu/flexcpu_thread.hh
+++ b/src/cpu/flexcpu/flexcpu_thread.hh
@@ -396,6 +396,12 @@ class FlexCPUThread : public ThreadContext
     void handleFault(std::shared_ptr<InflightInst> inst_ptr);
 
     /**
+     * Utility function for handling an interrupt. This function should only be
+     * called if an interrupt has actually been detected for this thread.
+     */
+    void handleInterrupt();
+
+    /**
      * This function checks if the thread should be active at this moment, and
      * whether or not we have a reasonable PC value ready to be able to
      * initiate another fetch at this time.
@@ -734,6 +740,8 @@ class FlexCPUThread : public ThreadContext
     // gotten from new.
 
     virtual ~FlexCPUThread();
+
+    void interrupt(Fault intr);
 
     const std::string& name() const
     { return _name; }


### PR DESCRIPTION
These are features that are necessary for fullsystem simulation.
However, no one has fully tested flexcpu for fullsystem yet.

cpu-flex: Added missing initialization code for fullsystem

Signed-off-by: Bradley Wang <radwang@ucdavis.edu>

cpu-flex: Simple thread-driven commit-time interrupts.

Change-Id: I540c331974cb42ef8985e0dcbe87e1e29f57a0e5
Signed-off-by: Bradley Wang <radwang@ucdavis.edu>