### PR TITLE
cpu-flex: Added alternative constraint for instruction window.

### DIFF
--- a/src/cpu/flexcpu/FlexCPU.py
+++ b/src/cpu/flexcpu/FlexCPU.py
@@ -65,15 +65,21 @@ class FlexCPU(BaseCPU):
     in_order_execute = Param.Bool(False, "Serialize all instruction "
                                          "execution.")
 
-    instruction_buffer_size = Param.Unsigned(0, "Size of the dynamic "
-                                             "instruction buffer. This buffer "
-                                             "is used for maintaining the "
-                                             "commit order of instructions. "
-                                             "Limiting this limits the number "
-                                             "of instructions that can be "
-                                             "handled at once before commit "
-                                             "(out of order). 0 implies an "
-                                             "infinitely large buffer.")
+    op_buffer_size = Param.Unsigned(0, "Size of the InflightInst buffer. This "
+                                       "buffer stores decoded (possibly "
+                                       "microcoded) instructions used for "
+                                       "maintaining the commit order of "
+                                       "instructions and microops. Limiting "
+                                       "this limits the number of "
+                                       "instructions AND microops that can be "
+                                       "handled at once before commit (out of "
+                                       "order). 0 implies an infinitely large "
+                                       "buffer.")
+
+    ignore_microops = Param.Bool(False, "When true, assume microops take 0 "
+                                 "time and treat max_inflight_insts as "
+                                 "counting the number of instructions, not "
+                                 "microops.")
 
     issue_latency = Param.Cycles(0, "Number of cycles each instruction takes "
                                     "to issue.")
@@ -96,10 +102,6 @@ class FlexCPU(BaseCPU):
                                             "default to forcing serialization "
                                             "in both directions when the "
                                             "flags are present.")
-
-    zero_time_microop_execution = Param.Bool(False, "Makes all microops "
-                                             "except the last for a macroop "
-                                             "take zero time.")
 
     @classmethod
     def memory_mode(cls):

--- a/src/cpu/flexcpu/flexcpu.cc
+++ b/src/cpu/flexcpu/flexcpu.cc
@@ -44,7 +44,7 @@ FlexCPU::FlexCPU(FlexCPUParams* params):
     BaseCPU(params),
     cacheBlockMask(~(cacheLineSize() - 1)),
     executionLatency(params->execution_latency),
-    zeroTimeMicroopExecution(params->zero_time_microop_execution),
+    zeroTimeMicroopExecution(params->ignore_microops),
     dataAddrTranslationUnit(this, Cycles(0),
                             0, name() + ".dtbUnit"),
     executionUnit(this, params->execution_latency,
@@ -74,7 +74,8 @@ FlexCPU::FlexCPU(FlexCPUParams* params):
                 params->fetch_buffer_size,
                 params->in_order_begin_execute,
                 params->in_order_execute,
-                params->instruction_buffer_size,
+                params->op_buffer_size,
+                params->ignore_microops,
                 params->strict_serialization,
                 params->stld_forward_enabled));
 
@@ -91,7 +92,8 @@ FlexCPU::FlexCPU(FlexCPUParams* params):
                 params->fetch_buffer_size,
                 params->in_order_begin_execute,
                 params->in_order_execute,
-                params->instruction_buffer_size,
+                params->op_buffer_size,
+                params->ignore_microops,
                 params->strict_serialization,
                 params->stld_forward_enabled));
 

--- a/src/cpu/flexcpu/inflight_inst.hh
+++ b/src/cpu/flexcpu/inflight_inst.hh
@@ -42,6 +42,15 @@
 #include "sim/core.hh"
 #include "sim/insttracer.hh"
 
+/**
+ * Dynamic instruction class for FlexCPU. Note that an InflightInst may only
+ * refer to a microop for microcoded instructions (similarly to StaticInst),
+ * so multiple InflightInsts (one per op) will make up one instruction in the
+ * trace for microcoded instructions.
+ *
+ * An InflightInst can also be "empty" to serve as a slot on the buffer prior
+ * to instruction decode.
+ */
 class InflightInst : public ExecContext,
                      public std::enable_shared_from_this<InflightInst>
 {


### PR DESCRIPTION
Common trace-based analysis tools have a configurable instruction window
within which to analyze programs. This emulates that behavior by
creating two separate constraints, (the existing) one which behaves more
like specific microarchitectures with ROBs that handle microcode (like
the ROB in O3), and a new constraint which constrains by the ISA
instructions encountered, ignoring the impact of microcode. This feature
is intended for use alongside the zero-time-microops feature, for
simulation of systems minimizing the impact of microcode, regardless of
the state of ISA implementations within gem5.

cpu-flex: Added alternative constraint to limit insts instead of ops.

Signed-off-by: Bradley Wang <radwang@ucdavis.edu>

Added some documentation, minor changes for clarity

Change-Id: Id44c369735e002e37bdb03bcdb8db3f475940dcf
Signed-off-by: Bradley Wang <radwang@ucdavis.edu>