### PR TITLE
adding visualizer for flexcpu

### DIFF
--- a/src/cpu/flexcpu/SConscript
+++ b/src/cpu/flexcpu/SConscript
@@ -49,6 +49,8 @@ if 'FlexCPU' in env['CPU_MODELS']:
     DebugFlag('FlexCPUDeps')
     DebugFlag('FlexCPUForwarder')
 
+    DebugFlag('FlexPipeView')
+
     CompoundFlag('FlexCPUAll', ['FlexCPUCoreEvent', 'FlexCPUInstEvent',
                               'FlexCPUThreadEvent', 'FlexCPUBranchPred',
                               'FlexCPUBufferDump', 'FlexCPUDeps',

--- a/src/cpu/flexcpu/flexcpu_thread.cc
+++ b/src/cpu/flexcpu/flexcpu_thread.cc
@@ -180,7 +180,7 @@ FlexCPUThread::advanceInst(TheISA::PCState next_pc)
 
         shared_ptr<InflightInst> inst_ptr =
             make_shared<InflightInst>(this, isa, &memIface, &x86Iface, seq_num,
-                                      next_pc, static_inst);
+                                      ++nextIssueNum, next_pc, static_inst);
 
         inflightInsts.push_back(inst_ptr);
         DPRINTF(FlexCPUThreadEvent, "Buffer size increased to %d\n",
@@ -208,7 +208,7 @@ FlexCPUThread::advanceInst(TheISA::PCState next_pc)
 
         shared_ptr<InflightInst> inst_ptr =
             make_shared<InflightInst>(this, isa, &memIface, &x86Iface, seq_num,
-                                      next_pc, static_inst);
+                                      ++nextIssueNum, next_pc, static_inst);
 
         inflightInsts.push_back(inst_ptr);
 
@@ -237,7 +237,7 @@ FlexCPUThread::advanceInst(TheISA::PCState next_pc)
     // result of the next decoding.
     shared_ptr<InflightInst> inst_ptr =
         make_shared<InflightInst>(this, isa, &memIface, &x86Iface, seq_num,
-                                  next_pc);
+                                  ++nextIssueNum, next_pc);
 
     inflightInsts.push_back(inst_ptr);
 
@@ -1085,7 +1085,6 @@ FlexCPUThread::onIssueAccessed(weak_ptr<InflightInst> inst)
         }
     }
 
-    inst_ptr->issueSeqNum(nextIssueNum++);
     populateDependencies(inst_ptr);
     populateUses(inst_ptr);
 

--- a/src/cpu/flexcpu/flexcpu_thread.hh
+++ b/src/cpu/flexcpu/flexcpu_thread.hh
@@ -45,6 +45,7 @@
 #include "cpu/pred/bpred_unit.hh"
 #include "cpu/reg_class.hh"
 #include "cpu/simple_thread.hh"
+#include "debug/FlexPipeView.hh"
 #include "mem/request.hh"
 
 class FlexCPU;

--- a/src/cpu/flexcpu/inflight_inst.cc
+++ b/src/cpu/flexcpu/inflight_inst.cc
@@ -41,6 +41,7 @@ InflightInst::InflightInst(ThreadContext* backing_context,
                            MemIface* backing_mem_iface,
                            X86Iface* backing_x86_iface,
                            InstSeqNum seq_num,
+                           InstSeqNum issue_seq_num,
                            const PCState& pc_,
                            StaticInstPtr inst_ref):
     backingContext(backing_context),
@@ -49,6 +50,7 @@ InflightInst::InflightInst(ThreadContext* backing_context,
     backingX86Interface(backing_x86_iface),
     _status(Empty),
     _seqNum(seq_num),
+    _issueSeqNum(issue_seq_num),
     _pcState(pc_)
 {
     _timingRecord.creationTick = curTick();

--- a/src/cpu/flexcpu/inflight_inst.cc
+++ b/src/cpu/flexcpu/inflight_inst.cc
@@ -29,6 +29,7 @@
  */
 
 #include "cpu/flexcpu/inflight_inst.hh"
+#include "debug/FlexPipeView.hh"
 
 using namespace std;
 
@@ -64,6 +65,52 @@ InflightInst::~InflightInst()
     // the object along with the instance, when the instance is no longer
     // needed.
     if (_traceData) delete _traceData;
+}
+
+void InflightInst::pipeTrace()
+{
+#if TRACING_ON
+    // Output the information about the lifecycle of a dynamic instruction in
+    // the pipeline including issueSeqNum, which is unique to each created
+    // InflightInst, followed by pc, micro pc, the static instruction if
+    // exists, and the Tick's when the instruction's state changes.
+    if (DTRACE(FlexPipeView)) {
+        if (!static_cast<bool>(instRef)) {
+            DPRINTFR(FlexPipeView,
+                     "pipe;%llu;%llx;%llx;null;"
+                     "%llu;%llu;%llu;%llu;%llu;%llu;%llu;%llu;%llu\n",
+                     this->issueSeqNum(),
+                     this->_pcState.pc(),
+                     this->_pcState.upc(),
+                     this->_timingRecord.creationTick,
+                     this->_timingRecord.decodeTick,
+                     this->_timingRecord.issueTick,
+                     this->_timingRecord.beginExecuteTick,
+                     this->_timingRecord.effAddredTick,
+                     this->_timingRecord.beginMemoryTick,
+                     this->_timingRecord.completionTick,
+                     this->_timingRecord.commitTick,
+                     this->_timingRecord.squashTick);
+        } else {
+            DPRINTFR(FlexPipeView,
+                     "pipe;%llu;%llx;%llx;%s;"
+                     "%llu;%llu;%llu;%llu;%llu;%llu;%llu;%llu;%llu\n",
+                     this->issueSeqNum(),
+                     this->_pcState.pc(),
+                     this->_pcState.upc(),
+                     this->instRef->disassemble(this->_pcState.npc()),
+                     this->_timingRecord.creationTick,
+                     this->_timingRecord.decodeTick,
+                     this->_timingRecord.issueTick,
+                     this->_timingRecord.beginExecuteTick,
+                     this->_timingRecord.effAddredTick,
+                     this->_timingRecord.beginMemoryTick,
+                     this->_timingRecord.completionTick,
+                     this->_timingRecord.commitTick,
+                     this->_timingRecord.squashTick);
+        }
+    }
+#endif
 }
 
 void

--- a/src/cpu/flexcpu/inflight_inst.hh
+++ b/src/cpu/flexcpu/inflight_inst.hh
@@ -86,29 +86,31 @@ class InflightInst : public ExecContext,
 
     struct TimingRecord
     {
+        // All Tick's are initialized to MaxTick, which means if a Tick hasn't
+        // been recorded, its value will be MaxTick
         // When was this InflightInst object created?
-        Tick creationTick;
+        Tick creationTick = MaxTick;
         // When was this InflightInst object provided with a StaticInst?
-        Tick decodeTick;
+        Tick decodeTick = MaxTick;
         // NOTE: may want to consider a rename stage.
         // When was this InflightInst object placed into consideration for
         // execution?
-        Tick issueTick;
+        Tick issueTick = MaxTick;
         // When did this InflightInst object get execution requested for it?
-        Tick beginExecuteTick;
+        Tick beginExecuteTick = MaxTick;
         // (For memory only) When did this InflightInst object have its
         // physical effective address(es) calculated?
-        Tick effAddredTick;
+        Tick effAddredTick = MaxTick;
         // (For memory only) When did this InflightInst object get memory
         // requested for it?
-        Tick beginMemoryTick;
+        Tick beginMemoryTick = MaxTick;
         // When were all steps for computing the state changes that this
         // InflightInst object will apply to committed state completed?
-        Tick completionTick;
+        Tick completionTick = MaxTick;
         // When was this InflightInst finally applied to committed state?
-        Tick commitTick;
+        Tick commitTick = MaxTick;
         // If squashed, when was this InflightInst squashed?
-        Tick squashTick;
+        Tick squashTick = MaxTick;
     };
 
     // Plain old container for storing where this instruction should retrieve
@@ -639,6 +641,8 @@ class InflightInst : public ExecContext,
     void syscall(int64_t callnum, Fault* fault) override;
 
     ThreadContext* tcBase() override;
+
+    void pipeTrace();
 
     /**
      * ARM-specific

--- a/src/cpu/flexcpu/inflight_inst.hh
+++ b/src/cpu/flexcpu/inflight_inst.hh
@@ -250,7 +250,8 @@ class InflightInst : public ExecContext,
   public:
     InflightInst(ThreadContext* backing_context, TheISA::ISA* backing_isa,
                  MemIface* backing_mem_iface, X86Iface* backing_x86_iface,
-                 InstSeqNum seq_num, const TheISA::PCState& pc_,
+                 InstSeqNum seq_num, InstSeqNum issue_seq_num,
+                 const TheISA::PCState& pc_,
                  StaticInstPtr inst_ref = StaticInst::nullStaticInstPtr);
 
     // Unimplemented copy due to presence of raw pointers.
@@ -522,18 +523,6 @@ class InflightInst : public ExecContext,
      */
     inline InstSeqNum issueSeqNum() const
     { return _issueSeqNum; }
-
-    /**
-     * Set the sequence number of the InflightInst
-     */
-    inline InstSeqNum seqNum(InstSeqNum seqNum)
-    { return _seqNum = seqNum; }
-
-    /**
-     * Set the sequence number of the InflightInst
-     */
-    inline InstSeqNum issueSeqNum(InstSeqNum seqNum)
-    { return _issueSeqNum = seqNum; }
 
     inline const StaticInstPtr& staticInst() const
     { return instRef; }

--- a/util/flexpipeviewer.py
+++ b/util/flexpipeviewer.py
@@ -1,0 +1,283 @@
+#! /usr/bin/env python3
+import argparse
+
+# This is the equivalent of MaxTick in gem5, which is MAX_INT of 64-bit
+# Here we assume the Tick's are 64-bit integers
+# Should be changed if the Tick's are 32-bit integers
+# MAX_INT (64-bit) = 2**64 - 1
+# MAX_INT (32-bit) = 2**32 - 1
+# MAX_TICK is only used for parsing the input
+MAX_TICK = 2**64 - 1
+# INVALID_TICK is the internal representation for Tick's that are not recorded
+INVALID_TICK = -1
+
+bg_color_map = {
+    "red": "\033[41m",
+    "green": "\033[42m",
+    "yellow": "\033[43m",
+    "blue": "\033[44m",
+    "magenta": "\033[45m",
+    "cyan": "\033[46m",
+    "white": "\033[47m",
+    "bright_black": "\033[100m",
+    "bright_red": "\033[101m",
+    "bright_green": "\033[102m",
+    "bright_yellow": "\033[103m",
+    "bright_blue": "\033[104m",
+    "bright_magenta": "\033[105m",
+    "bright_cyan": "\033[106m",
+    "bright_white": "\033[107m",
+    "black": "\033[0m"
+}
+
+stage_color_map = {
+    "f": "blue",
+    "d": "yellow",
+    "i": "red",
+    "e": "cyan",
+    "a": "cyan",
+    "m": "cyan",
+    "z": "green",
+    "c": "blue",
+    "s": "magenta",
+    "\n": "black"
+}
+
+# f: creationTick (inst created)
+# d: decodeTick (inst decoded)
+# i: issueTick (issued)
+# e: beginExecuteTick (execute request sent)
+# a: effectiveAddressTick (address available)
+# m: beginMemoryTick (memory access request sent)
+# z: completionTick (execute stage is done)
+# c: commitTick (inst committed)
+# s: squashTick (inst squashed)
+
+stages = ["f", "d", "i", "e", "a", "m", "z", "c", "s"]
+
+stages_fullname = ["fetch", "decode", "issue", "begin execute", "effAddress",
+                   "begin memory", "complete", "commit", "squash"]
+
+bg_color_char_lambda = lambda color, char : bg_color_map[color] + char \
+                                            + bg_color_map["black"]
+
+max_tick_to_invalid_tick_lambda = lambda tick: tick if tick != MAX_TICK \
+                                                    else INVALID_TICK
+
+def colorize_pipeline(pipeline, start_pos, end_pos, bg_coloring_lambda, wrap):
+    curr_color = stage_color_map[pipeline[start_pos]]
+    if wrap:
+        i = start_pos
+        width = len(pipeline)
+        end_pos = end_pos % width
+        while not i == end_pos:
+            if pipeline[i].isalpha():
+                curr_color = stage_color_map[pipeline[i]]
+            pipeline[i] = bg_coloring_lambda(curr_color, pipeline[i])
+            i = (i + 1) % width
+    else:
+        for i in range(start_pos, end_pos):
+            if pipeline[i].isalpha():
+                curr_color = stage_color_map[pipeline[i]]
+            pipeline[i] = bg_coloring_lambda(curr_color, pipeline[i])
+    return pipeline
+
+def no_colorize_pipeline(pipeline, start_pos, end_pos, bg_color_lambda):
+    return pipeline
+
+def parse_pipe(line):
+    seq_num = int(line[1])
+    pc = int(line[2], 16)
+    upc = int(line[3], 16)
+    inst = line[4].strip()
+
+    creationTick = max_tick_to_invalid_tick_lambda(int(line[5]))
+    decodeTick = max_tick_to_invalid_tick_lambda(int(line[6]))
+    issueTick = max_tick_to_invalid_tick_lambda(int(line[7]))
+    beginExecuteTick = max_tick_to_invalid_tick_lambda(int(line[8]))
+    effAddredTick = max_tick_to_invalid_tick_lambda(int(line[9]))
+    beginMemoryTick = max_tick_to_invalid_tick_lambda(int(line[10]))
+    completionTick = max_tick_to_invalid_tick_lambda(int(line[11]))
+    commitTick = max_tick_to_invalid_tick_lambda(int(line[12]))
+    squashTick = max_tick_to_invalid_tick_lambda(int(line[13]))
+
+    ticks = (creationTick, decodeTick, issueTick, beginExecuteTick,
+             effAddredTick, beginMemoryTick, completionTick, commitTick,
+             squashTick)
+    return seq_num, pc, upc, inst, ticks
+
+def pipe_to_string(line, tick_start, tick_end, coloring_fnct, width,
+                   cycle_time, dep):
+    ticks_per_line = cycle_time * width
+    # decode the instruction info
+    seq_num, pc, upc, inst, ticks = parse_pipe(line)
+    creationTick = ticks[0]
+    squashTick = ticks[-1]
+    wrap_around = False
+
+    if creationTick < tick_start or creationTick > tick_end:
+        return False, -1, None
+
+    # [...............f............]
+    #  ^
+    #  start_tick <- the tick at the first position of the pipeline
+    start_tick = creationTick - creationTick % ticks_per_line
+    end_tick = max(ticks)
+
+    # the lifespan of an instruction can exceed ticks_per_line,
+    # so we need multiple lines to represent the lifecycle of
+    # the instruction
+    n_lines = end_tick // ticks_per_line - start_tick // ticks_per_line + 1
+    if n_lines == 2 and \
+       end_tick // ticks_per_line - start_tick // ticks_per_line  < width:
+        n_lines = 1
+        wrap_around = True
+
+    # [...............f......c.....]
+    #                 ^      ^
+    #           start_pos   end_pos
+    start_pos = (creationTick - start_tick) // cycle_time
+    end_pos = (end_tick - start_tick) // cycle_time + 1
+
+    # the pipeline looks like:
+    #   [=======f====] if the instruction is squashed
+    #   [.......f....] if the instruction is committed
+    if squashTick == INVALID_TICK:
+        pipe = ["."] * (width * n_lines)
+    else:
+        pipe = ["="] * (width * n_lines)
+
+    for tick, name in zip(ticks, stages):
+        if not tick == INVALID_TICK:
+            if wrap_around:
+                pipe[((tick - start_tick) // cycle_time) % width] = name
+            else:
+                pipe[((tick - start_tick) // cycle_time)] = name
+
+    # add color to pipeline
+    pipe = coloring_fnct(pipe, start_pos, end_pos, bg_color_char_lambda,
+                         wrap_around)
+
+    if seq_num in dep:
+        dependencies = ", ".join(list(map(str, dep[seq_num])))
+    else:
+        dependencies = ""
+
+    # split the pipeline to equal chunks of length `width`
+    _pipe = []
+    for i in range(n_lines):
+        _pipe.append("".join(pipe[i*width:(i+1)*width]))
+    pipe = _pipe
+
+    # format the output
+    if (len(pipe) == 1):
+        pipe[0] = "({:10d}) [{}] 0x{:08x}:{:d} {:6d} [{:10}] {}".format(
+                  start_tick, pipe[0], pc, upc, seq_num, dependencies, inst)
+    else:
+        pipe[0] = "({:10d}) [{}  0x{:08x}:{:d} {:6d} [{:10}] {}".format(
+                  start_tick, pipe[0], pc, upc, seq_num, dependencies, inst)
+        for i in range(1, len(pipe)):
+            pipe[i] = "{:12}  {}".format("", pipe[i])
+        pipe[-1] = "{}]".format(pipe[-1])
+
+    pipe.append("")
+    info = "\n".join(pipe)
+    return True, seq_num, info
+
+
+def parse_dependency(line):
+    # inst[seq_num] depends on inst[parent_seq_num]
+    seq_num = int(line[1])
+    parent_seq_num = int(line[2])
+    return seq_num, parent_seq_num
+
+def parser(input_file, output_file, tick_start, tick_end, color, width,
+           cycle_time):
+    curr_batch_seq_num = 0
+    insts = {}
+    dep = {}
+    max_seq_num = -1
+
+    # choosing the coloring function
+    if color:
+        coloring_fnct = colorize_pipeline
+    else:
+        coloring_fnct = no_colorize_pipeline
+
+    # read the debugging output
+    with open(input_file, "r") as f:
+        seq_num = -1
+        for line in f:
+            line = line.strip().split(";")
+            if line[0] == "pipe":
+                in_tick_range, seq_num, info = pipe_to_string(line, tick_start,
+                               tick_end, coloring_fnct, width, cycle_time, dep)
+                if in_tick_range:
+                    insts[seq_num] = info
+                max_seq_num = max(seq_num, max_seq_num)
+            elif line[0] == "dep":
+                seq_num, parent_seq_num = parse_dependency(line)
+                if not seq_num in dep:
+                    dep[seq_num] = {parent_seq_num}
+                else:
+                    dep[seq_num].add(parent_seq_num)
+
+    # write the formatted pipeline view to the output file
+    with open(output_file, "w") as g:
+        # format the legends of the pipeline
+        legends = []
+        stages_with_color = [bg_color_map[stage_color_map[stage]] + stage +
+                             bg_color_map["black"] for stage in stages]
+        for name, fullname in zip(stages_fullname, stages_with_color):
+            legends.append("{}: {}".format(name, fullname))
+        g.write(", ".join(legends))
+        g.write("\n")
+
+        # format the title of the output
+        headers = "{:^12} {} {:^12} {:6} {:^12} {}\n".format("tick",
+                  "pipeline".center(width+2, " "), "pc:upc", "seqnum",
+                  "dependencies", "instruction")
+        g.write(headers)
+
+        # seq_num starts from 1
+        for seq_num in range(1, max_seq_num+1):
+            if seq_num in insts:
+                g.write(insts[seq_num])
+
+def main():
+    default_options = {
+        "input_file"  : "",
+        "output_file" : "trace.out",
+        "tick_start"  : 0,
+        "tick_end"    : MAX_TICK,
+        "color"       : True,
+        "width"       : 80,
+        "cycle_time"  : 1000
+    }
+
+    argparser = argparse.ArgumentParser(description="FlexCPU pipeline viewer")
+    argparser.add_argument("-i", "--input-file",
+                           required=True)
+    argparser.add_argument("-o", "--output-file",
+                           default=default_options["output_file"])
+    argparser.add_argument("-s", "--tick-start",
+                           default=default_options["tick_start"],
+                           type=int)
+    argparser.add_argument("-e", "--tick-end",
+                           default=default_options["tick_end"],
+                           type=int)
+    argparser.add_argument("-l", "--color",
+                           action='store_true',
+                           default=default_options["color"])
+    argparser.add_argument("-w", "--width",
+                           type=int,
+                           default=default_options["width"])
+    argparser.add_argument("-c", "--cycle-time",
+                           type=int,
+                           default=default_options["cycle_time"])
+    args = argparser.parse_args()
+    print(vars(args))
+    parser(**vars(args))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Usage:
```
gem5/util/flexpipeviewer.py -w 80 -i m5out/simout -o trace.out
```
where `80` is the pipeline width, `m5out/simout` is the input file and `trace.out` is the output file.
~~There are a few issues,~~
- ~~Haven't supported start_tick and end_tick yet.~~ ~~Won't support~~ Supported now.
- ~~Haven't supported printing instruction dependency yet.~~ Supported now.
- ~~There are a few stages happen at the same time for some instructions, but only one stage is visible.~~ It's better this way.
- ~~Since seq_num is reused, there are several instructions with the same seq_num, and since dependencies are determined by seq_num, this causes confusion.~~ Solved!
- ~~We need to sort the instructions by the sequence numbers. Ideally, we can read the instructions chunk by chunk and sort them if earlier instructions do not appear much latter in the output. However, this is not the case. The code now reads and sorts all instructions, which is slow.~~ The performance is acceptable, for now.