### PR TITLE
Deprecate SlavePort and MasterPort Classes and change terminology

### DIFF
--- a/src/arch/arm/ArmTLB.py
+++ b/src/arch/arm/ArmTLB.py
@@ -54,7 +54,7 @@ class ArmTableWalker(ClockedObject):
     # to the Stage2MMU, and shared by the two table walkers, but we
     # access it through the ITB and DTB walked objects in the CPU for
     # symmetry with the other ISAs.
-    port = MasterPort("Port used by the two table walkers")
+    port = RequestPort("Port used by the two table walkers")
 
     sys = Param.System(Parent.any, "system object parameter")
 

--- a/src/arch/arm/fastmodel/FastModel.py
+++ b/src/arch/arm/fastmodel/FastModel.py
@@ -75,21 +75,21 @@ class VectorAmbaInitiatorSocket(VectorPort):
         super(VectorAmbaInitiatorSocket, self).__init__(
                 my_role, desc, is_source=True)
 
-class ScMasterPort(Port):
+class ScRequestPort(Port):
     def __init__(self, desc, port_type):
         my_role = SC_MASTER_PORT_ROLE(port_type)
         peer_role = SC_SLAVE_PORT_ROLE(port_type)
         Port.compat(my_role, peer_role)
 
-        super(ScMasterPort, self).__init__(my_role, desc)
+        super(ScRequestPort, self).__init__(my_role, desc)
 
-class ScSlavePort(Port):
+class ScResponsePort(Port):
     def __init__(self, desc, port_type):
         my_role = SC_SLAVE_PORT_ROLE(port_type)
         peer_role = SC_MASTER_PORT_ROLE(port_type)
         Port.compat(my_role, peer_role)
 
-        super(ScSlavePort, self).__init__(my_role, desc)
+        super(ScResponsePort, self).__init__(my_role, desc)
 
 class AmbaToTlmBridge64(SystemC_ScModule):
     type = 'AmbaToTlmBridge64'

--- a/src/arch/generic/BaseTLB.py
+++ b/src/arch/generic/BaseTLB.py
@@ -34,4 +34,4 @@ class BaseTLB(SimObject):
     cxx_header = "arch/generic/tlb.hh"
     # Ports to connect with other TLB levels
     slave  = VectorSlavePort("Port closer to the CPU side")
-    master = MasterPort("Port closer to memory side")
+    master = RequestPort("Port closer to memory side")

--- a/src/arch/generic/BaseTLB.py
+++ b/src/arch/generic/BaseTLB.py
@@ -33,5 +33,5 @@ class BaseTLB(SimObject):
     abstract = True
     cxx_header = "arch/generic/tlb.hh"
     # Ports to connect with other TLB levels
-    slave  = VectorSlavePort("Port closer to the CPU side")
-    master = MasterPort("Port closer to memory side")
+    slave  = VectorResponsePort("Port closer to the CPU side")
+    master = RequestPort("Port closer to memory side")

--- a/src/arch/riscv/RiscvTLB.py
+++ b/src/arch/riscv/RiscvTLB.py
@@ -37,7 +37,7 @@ class RiscvPagetableWalker(ClockedObject):
     type = 'RiscvPagetableWalker'
     cxx_class = 'RiscvISA::Walker'
     cxx_header = 'arch/riscv/pagetable_walker.hh'
-    port = MasterPort("Port for the hardware table walker")
+    port = RequestPort("Port for the hardware table walker")
     system = Param.System(Parent.any, "system object")
     num_squash_per_cycle = Param.Unsigned(4,
             "Number of outstanding walks that can be squashed per cycle")

--- a/src/arch/riscv/pagetable_walker.hh
+++ b/src/arch/riscv/pagetable_walker.hh
@@ -58,11 +58,11 @@ namespace RiscvISA
     {
       protected:
         // Port for accessing memory
-        class WalkerPort : public MasterPort
+        class WalkerPort : public RequestPort
         {
           public:
             WalkerPort(const std::string &_name, Walker * _walker) :
-                  MasterPort(_name, _walker), walker(_walker)
+                  RequestPort(_name, _walker), walker(_walker)
             {}
 
           protected:

--- a/src/arch/x86/X86LocalApic.py
+++ b/src/arch/x86/X86LocalApic.py
@@ -48,11 +48,11 @@ class X86LocalApic(BaseInterrupts):
     type = 'X86LocalApic'
     cxx_class = 'X86ISA::Interrupts'
     cxx_header = 'arch/x86/interrupts.hh'
-    int_master = MasterPort("Port for sending interrupt messages")
-    int_slave = SlavePort("Port for receiving interrupt messages")
+    int_master = RequestPort("Port for sending interrupt messages")
+    int_slave = ResponsePort("Port for receiving interrupt messages")
     int_latency = Param.Latency('1ns', \
             "Latency for an interrupt to propagate through this device.")
-    pio = SlavePort("Programmed I/O port")
+    pio = ResponsePort("Programmed I/O port")
     system = Param.System(Parent.any, "System this device is part of")
 
     pio_latency = Param.Latency('100ns', 'Programmed IO latency')

--- a/src/arch/x86/X86TLB.py
+++ b/src/arch/x86/X86TLB.py
@@ -43,7 +43,7 @@ class X86PagetableWalker(ClockedObject):
     type = 'X86PagetableWalker'
     cxx_class = 'X86ISA::Walker'
     cxx_header = 'arch/x86/pagetable_walker.hh'
-    port = MasterPort("Port for the hardware table walker")
+    port = RequestPort("Port for the hardware table walker")
     system = Param.System(Parent.any, "system object")
     num_squash_per_cycle = Param.Unsigned(4,
             "Number of outstanding walks that can be squashed per cycle")

--- a/src/arch/x86/interrupts.cc
+++ b/src/arch/x86/interrupts.cc
@@ -288,12 +288,12 @@ X86ISA::Interrupts::setThreadContext(ThreadContext *_tc)
 void
 X86ISA::Interrupts::init()
 {
-    panic_if(!intMasterPort.isConnected(),
+    panic_if(!intRequestPort.isConnected(),
             "Int port not connected to anything!");
     panic_if(!pioPort.isConnected(),
             "Pio port of %s not connected to anything!", name());
 
-    intSlavePort.sendRangeChange();
+    intResponsePort.sendRangeChange();
     pioPort.sendRangeChange();
 }
 
@@ -541,7 +541,7 @@ X86ISA::Interrupts::setReg(ApicRegIndex reg, uint32_t val)
             regs[APIC_INTERRUPT_COMMAND_LOW] = low;
             for (auto id: apics) {
                 PacketPtr pkt = buildIntTriggerPacket(id, message);
-                intMasterPort.sendMessage(pkt, sys->isTimingMode(),
+                intRequestPort.sendMessage(pkt, sys->isTimingMode(),
                         [this](PacketPtr pkt) { completeIPI(pkt); });
             }
             newVal = regs[APIC_INTERRUPT_COMMAND_LOW];
@@ -603,8 +603,8 @@ X86ISA::Interrupts::Interrupts(Params *p)
       pendingStartup(false), startupVector(0),
       startedUp(false), pendingUnmaskableInt(false),
       pendingIPIs(0),
-      intSlavePort(name() + ".int_slave", this, this),
-      intMasterPort(name() + ".int_master", this, this, p->int_latency),
+      intResponsePort(name() + ".int_slave", this, this),
+      intRequestPort(name() + ".int_master", this, this, p->int_latency),
       pioPort(this), pioDelay(p->pio_latency)
 {
     memset(regs, 0, sizeof(regs));

--- a/src/arch/x86/interrupts.hh
+++ b/src/arch/x86/interrupts.hh
@@ -174,8 +174,8 @@ class Interrupts : public BaseInterrupts
     int initialApicId;
 
     // Ports for interrupts.
-    IntSlavePort<Interrupts> intSlavePort;
-    IntMasterPort<Interrupts> intMasterPort;
+    IntResponsePort<Interrupts> intResponsePort;
+    IntRequestPort<Interrupts> intRequestPort;
 
     // Port for memory mapped register accesses.
     PioPort<Interrupts> pioPort;
@@ -229,9 +229,9 @@ class Interrupts : public BaseInterrupts
                   PortID idx=InvalidPortID) override
     {
         if (if_name == "int_master") {
-            return intMasterPort;
+            return intRequestPort;
         } else if (if_name == "int_slave") {
-            return intSlavePort;
+            return intResponsePort;
         } else if (if_name == "pio") {
             return pioPort;
         }

--- a/src/arch/x86/pagetable_walker.hh
+++ b/src/arch/x86/pagetable_walker.hh
@@ -57,11 +57,11 @@ namespace X86ISA
     {
       protected:
         // Port for accessing memory
-        class WalkerPort : public MasterPort
+        class WalkerPort : public RequestPort
         {
           public:
             WalkerPort(const std::string &_name, Walker * _walker) :
-                  MasterPort(_name, _walker), walker(_walker)
+                  RequestPort(_name, _walker), walker(_walker)
             {}
 
           protected:

--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -184,25 +184,25 @@ class BaseCPU(ClockedObject):
     if buildEnv['TARGET_ISA'] in ['x86', 'arm', 'riscv']:
         _cached_ports += ["itb.walker.port", "dtb.walker.port"]
 
-    _uncached_slave_ports = []
-    _uncached_master_ports = []
+    _uncached_response_ports = []
+    _uncached_request_ports = []
     if buildEnv['TARGET_ISA'] == 'x86':
-        _uncached_slave_ports += ["interrupts[0].pio",
-                                  "interrupts[0].int_slave"]
-        _uncached_master_ports += ["interrupts[0].int_master"]
+        _uncached_response_ports += ["interrupts[0].pio",
+                                  "interrupts[0].int_responder"]
+        _uncached_request_ports += ["interrupts[0].int_requestor"]
 
     def createInterruptController(self):
         self.interrupts = [ArchInterrupts() for i in range(self.numThreads)]
 
     def connectCachedPorts(self, bus):
         for p in self._cached_ports:
-            exec('self.%s = bus.slave' % p)
+            exec('self.%s = bus.responder' % p)
 
     def connectUncachedPorts(self, bus):
-        for p in self._uncached_slave_ports:
-            exec('self.%s = bus.master' % p)
-        for p in self._uncached_master_ports:
-            exec('self.%s = bus.slave' % p)
+        for p in self._uncached_response_ports:
+            exec('self.%s = bus.requestor' % p)
+        for p in self._uncached_request_ports:
+            exec('self.%s = bus.responder' % p)
 
     def connectAllPorts(self, cached_bus, uncached_bus = None):
         self.connectCachedPorts(cached_bus)
@@ -239,7 +239,7 @@ class BaseCPU(ClockedObject):
         self.toL2Bus = xbar if xbar else L2XBar()
         self.connectCachedPorts(self.toL2Bus)
         self.l2cache = l2c
-        self.toL2Bus.master = self.l2cache.cpu_side
+        self.toL2Bus.requestor = self.l2cache.cpu_side
         self._cached_ports = ['l2cache.mem_side']
 
     def createThreads(self):

--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -177,8 +177,8 @@ class BaseCPU(ClockedObject):
 
     tracer = Param.InstTracer(default_tracer, "Instruction tracer")
 
-    icache_port = MasterPort("Instruction Port")
-    dcache_port = MasterPort("Data Port")
+    icache_port = RequestPort("Instruction Port")
+    dcache_port = RequestPort("Data Port")
     _cached_ports = ['icache_port', 'dcache_port']
 
     if buildEnv['TARGET_ISA'] in ['x86', 'arm', 'riscv']:

--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -184,25 +184,25 @@ class BaseCPU(ClockedObject):
     if buildEnv['TARGET_ISA'] in ['x86', 'arm', 'riscv']:
         _cached_ports += ["itb.walker.port", "dtb.walker.port"]
 
-    _uncached_response_ports = []
-    _uncached_request_ports = []
+    _uncached_slave_ports = []
+    _uncached_master_ports = []
     if buildEnv['TARGET_ISA'] == 'x86':
-        _uncached_response_ports += ["interrupts[0].pio",
-                                  "interrupts[0].int_responder"]
-        _uncached_request_ports += ["interrupts[0].int_requestor"]
+        _uncached_slave_ports += ["interrupts[0].pio",
+                                  "interrupts[0].int_slave"]
+        _uncached_master_ports += ["interrupts[0].int_master"]
 
     def createInterruptController(self):
         self.interrupts = [ArchInterrupts() for i in range(self.numThreads)]
 
     def connectCachedPorts(self, bus):
         for p in self._cached_ports:
-            exec('self.%s = bus.responder' % p)
+            exec('self.%s = bus.slave' % p)
 
     def connectUncachedPorts(self, bus):
-        for p in self._uncached_response_ports:
-            exec('self.%s = bus.requestor' % p)
-        for p in self._uncached_request_ports:
-            exec('self.%s = bus.responder' % p)
+        for p in self._uncached_slave_ports:
+            exec('self.%s = bus.master' % p)
+        for p in self._uncached_master_ports:
+            exec('self.%s = bus.slave' % p)
 
     def connectAllPorts(self, cached_bus, uncached_bus = None):
         self.connectCachedPorts(cached_bus)
@@ -239,7 +239,7 @@ class BaseCPU(ClockedObject):
         self.toL2Bus = xbar if xbar else L2XBar()
         self.connectCachedPorts(self.toL2Bus)
         self.l2cache = l2c
-        self.toL2Bus.requestor = self.l2cache.cpu_side
+        self.toL2Bus.master = self.l2cache.cpu_side
         self._cached_ports = ['l2cache.mem_side']
 
     def createThreads(self):

--- a/src/cpu/base.hh
+++ b/src/cpu/base.hh
@@ -163,7 +163,7 @@ class BaseCPU : public ClockedObject
     virtual PortProxy::SendFunctionalFunc
     getSendFunctional()
     {
-        auto port = dynamic_cast<MasterPort *>(&getDataPort());
+        auto port = dynamic_cast<RequestPort *>(&getDataPort());
         assert(port);
         return [port](PacketPtr pkt)->void { port->sendFunctional(pkt); };
     }

--- a/src/cpu/checker/cpu.cc
+++ b/src/cpu/checker/cpu.cc
@@ -113,13 +113,13 @@ CheckerCPU::setSystem(System *system)
 }
 
 void
-CheckerCPU::setIcachePort(MasterPort *icache_port)
+CheckerCPU::setIcachePort(RequestPort *icache_port)
 {
     icachePort = icache_port;
 }
 
 void
-CheckerCPU::setDcachePort(MasterPort *dcache_port)
+CheckerCPU::setDcachePort(RequestPort *dcache_port)
 {
     dcachePort = dcache_port;
 }

--- a/src/cpu/checker/cpu.hh
+++ b/src/cpu/checker/cpu.hh
@@ -99,9 +99,9 @@ class CheckerCPU : public BaseCPU, public ExecContext
 
     void setSystem(System *system);
 
-    void setIcachePort(MasterPort *icache_port);
+    void setIcachePort(RequestPort *icache_port);
 
-    void setDcachePort(MasterPort *dcache_port);
+    void setDcachePort(RequestPort *dcache_port);
 
     Port &
     getDataPort() override
@@ -127,8 +127,8 @@ class CheckerCPU : public BaseCPU, public ExecContext
 
     System *systemPtr;
 
-    MasterPort *icachePort;
-    MasterPort *dcachePort;
+    RequestPort *icachePort;
+    RequestPort *dcachePort;
 
     ThreadContext *tc;
 

--- a/src/cpu/kvm/base.hh
+++ b/src/cpu/kvm/base.hh
@@ -572,15 +572,15 @@ class BaseKvmCPU : public BaseCPU
 
 
     /**
-     * KVM memory port.  Uses default MasterPort behavior and provides an
+     * KVM memory port.  Uses default RequestPort behavior and provides an
      * interface for KVM to transparently submit atomic or timing requests.
      */
-    class KVMCpuPort : public MasterPort
+    class KVMCpuPort : public RequestPort
     {
 
       public:
         KVMCpuPort(const std::string &_name, BaseKvmCPU *_cpu)
-            : MasterPort(_name, _cpu), cpu(_cpu), activeMMIOReqs(0)
+            : RequestPort(_name, _cpu), cpu(_cpu), activeMMIOReqs(0)
         { }
         /**
          * Interface to send Atomic or Timing IO request.  Assumes that the pkt

--- a/src/cpu/minor/cpu.hh
+++ b/src/cpu/minor/cpu.hh
@@ -95,7 +95,7 @@ class MinorCPU : public BaseCPU
   public:
     /** Provide a non-protected base class for Minor's Ports as derived
      *  classes are created by Fetch1 and Execute */
-    class MinorCPUPort : public MasterPort
+    class MinorCPUPort : public RequestPort
     {
       public:
         /** The enclosing cpu */
@@ -103,7 +103,7 @@ class MinorCPU : public BaseCPU
 
       public:
         MinorCPUPort(const std::string& name_, MinorCPU &cpu_)
-            : MasterPort(name_, &cpu_), cpu(cpu_)
+            : RequestPort(name_, &cpu_), cpu(cpu_)
         { }
 
     };

--- a/src/cpu/o3/fetch.hh
+++ b/src/cpu/o3/fetch.hh
@@ -87,7 +87,7 @@ class DefaultFetch
     /**
      * IcachePort class for instruction fetch.
      */
-    class IcachePort : public MasterPort
+    class IcachePort : public RequestPort
     {
       protected:
         /** Pointer to fetch. */
@@ -96,7 +96,7 @@ class DefaultFetch
       public:
         /** Default constructor. */
         IcachePort(DefaultFetch<Impl> *_fetch, FullO3CPU<Impl>* _cpu)
-            : MasterPort(_cpu->name() + ".icache_port", _cpu), fetch(_fetch)
+            : RequestPort(_cpu->name() + ".icache_port", _cpu), fetch(_fetch)
         { }
 
       protected:
@@ -377,7 +377,7 @@ class DefaultFetch
     /** The decoder. */
     TheISA::Decoder *decoder[Impl::MaxThreads];
 
-    MasterPort &getInstPort() { return icachePort; }
+    RequestPort &getInstPort() { return icachePort; }
 
   private:
     DynInstPtr buildInst(ThreadID tid, StaticInstPtr staticInst,

--- a/src/cpu/o3/lsq.hh
+++ b/src/cpu/o3/lsq.hh
@@ -119,7 +119,7 @@ class LSQ
     /**
      * DcachePort class for the load/store queue.
      */
-    class DcachePort : public MasterPort
+    class DcachePort : public RequestPort
     {
       protected:
 
@@ -130,7 +130,7 @@ class LSQ
       public:
         /** Default constructor. */
         DcachePort(LSQ<Impl> *_lsq, FullO3CPU<Impl>* _cpu)
-            : MasterPort(_cpu->name() + ".dcache_port", _cpu), lsq(_lsq),
+            : RequestPort(_cpu->name() + ".dcache_port", _cpu), lsq(_lsq),
               cpu(_cpu)
         { }
 
@@ -1053,7 +1053,7 @@ class LSQ
     /** Another store port is in use */
     void cachePortBusy(bool is_load);
 
-    MasterPort &getDataPort() { return dcachePort; }
+    RequestPort &getDataPort() { return dcachePort; }
 
   protected:
     /** D-cache is blocked */

--- a/src/cpu/o3/lsq_unit.hh
+++ b/src/cpu/o3/lsq_unit.hh
@@ -238,7 +238,7 @@ class LSQUnit
     void regStats();
 
     /** Sets the pointer to the dcache port. */
-    void setDcachePort(MasterPort *dcache_port);
+    void setDcachePort(RequestPort *dcache_port);
 
     /** Perform sanity checks after a drain. */
     void drainSanityCheck() const;
@@ -398,7 +398,7 @@ class LSQUnit
     LSQ *lsq;
 
     /** Pointer to the dcache port.  Used only for sending. */
-    MasterPort *dcachePort;
+    RequestPort *dcachePort;
 
     /** Particularisation of the LSQSenderState to the LQ. */
     class LQSenderState : public LSQSenderState

--- a/src/cpu/o3/lsq_unit_impl.hh
+++ b/src/cpu/o3/lsq_unit_impl.hh
@@ -245,7 +245,7 @@ LSQUnit<Impl>::regStats()
 
 template<class Impl>
 void
-LSQUnit<Impl>::setDcachePort(MasterPort *dcache_port)
+LSQUnit<Impl>::setDcachePort(RequestPort *dcache_port)
 {
     dcachePort = dcache_port;
 }

--- a/src/cpu/simple/atomic.cc
+++ b/src/cpu/simple/atomic.cc
@@ -272,7 +272,7 @@ AtomicSimpleCPU::suspendContext(ThreadID thread_num)
 }
 
 Tick
-AtomicSimpleCPU::sendPacket(MasterPort &port, const PacketPtr &pkt)
+AtomicSimpleCPU::sendPacket(RequestPort &port, const PacketPtr &pkt)
 {
     return port.sendAtomic(pkt);
 }

--- a/src/cpu/simple/atomic.hh
+++ b/src/cpu/simple/atomic.hh
@@ -101,7 +101,7 @@ class AtomicSimpleCPU : public BaseSimpleCPU
      */
     bool tryCompleteDrain();
 
-    virtual Tick sendPacket(MasterPort &port, const PacketPtr &pkt);
+    virtual Tick sendPacket(RequestPort &port, const PacketPtr &pkt);
 
     /**
      * An AtomicCPUPort overrides the default behaviour of the
@@ -109,13 +109,13 @@ class AtomicSimpleCPU : public BaseSimpleCPU
      * also provides an implementation for the purely virtual timing
      * functions and panics on either of these.
      */
-    class AtomicCPUPort : public MasterPort
+    class AtomicCPUPort : public RequestPort
     {
 
       public:
 
         AtomicCPUPort(const std::string &_name, BaseSimpleCPU* _cpu)
-            : MasterPort(_name, _cpu)
+            : RequestPort(_name, _cpu)
         { }
 
       protected:

--- a/src/cpu/simple/noncaching.cc
+++ b/src/cpu/simple/noncaching.cc
@@ -52,7 +52,7 @@ NonCachingSimpleCPU::verifyMemoryMode() const
 }
 
 Tick
-NonCachingSimpleCPU::sendPacket(MasterPort &port, const PacketPtr &pkt)
+NonCachingSimpleCPU::sendPacket(RequestPort &port, const PacketPtr &pkt)
 {
     if (system->isMemAddr(pkt->getAddr())) {
         system->getPhysMem().access(pkt);

--- a/src/cpu/simple/noncaching.hh
+++ b/src/cpu/simple/noncaching.hh
@@ -53,7 +53,7 @@ class NonCachingSimpleCPU : public AtomicSimpleCPU
     void verifyMemoryMode() const override;
 
   protected:
-    Tick sendPacket(MasterPort &port, const PacketPtr &pkt) override;
+    Tick sendPacket(RequestPort &port, const PacketPtr &pkt) override;
 };
 
 #endif // __CPU_SIMPLE_NONCACHING_HH__

--- a/src/cpu/simple/timing.hh
+++ b/src/cpu/simple/timing.hh
@@ -155,12 +155,12 @@ class TimingSimpleCPU : public BaseSimpleCPU
      * scheduling of handling of incoming packets in the following
      * cycle.
      */
-    class TimingCPUPort : public MasterPort
+    class TimingCPUPort : public RequestPort
     {
       public:
 
         TimingCPUPort(const std::string& _name, TimingSimpleCPU* _cpu)
-            : MasterPort(_name, _cpu), cpu(_cpu),
+            : RequestPort(_name, _cpu), cpu(_cpu),
               retryRespEvent([this]{ sendRetryResp(); }, name())
         { }
 

--- a/src/cpu/testers/directedtest/InvalidateGenerator.cc
+++ b/src/cpu/testers/directedtest/InvalidateGenerator.cc
@@ -54,7 +54,7 @@ InvalidateGenerator::~InvalidateGenerator()
 bool
 InvalidateGenerator::initiate()
 {
-    MasterPort* port;
+    RequestPort* port;
     Request::Flags flags;
     PacketPtr pkt;
     Packet::Command cmd;

--- a/src/cpu/testers/directedtest/RubyDirectedTester.cc
+++ b/src/cpu/testers/directedtest/RubyDirectedTester.cc
@@ -105,7 +105,7 @@ RubyDirectedTester::CpuPort::recvTimingResp(PacketPtr pkt)
     return true;
 }
 
-MasterPort*
+RequestPort*
 RubyDirectedTester::getCpuPort(int idx)
 {
     assert(idx >= 0 && idx < ports.size());

--- a/src/cpu/testers/directedtest/RubyDirectedTester.hh
+++ b/src/cpu/testers/directedtest/RubyDirectedTester.hh
@@ -47,7 +47,7 @@ class DirectedGenerator;
 class RubyDirectedTester : public ClockedObject
 {
   public:
-    class CpuPort : public MasterPort
+    class CpuPort : public RequestPort
     {
       private:
         RubyDirectedTester *tester;
@@ -55,7 +55,7 @@ class RubyDirectedTester : public ClockedObject
       public:
         CpuPort(const std::string &_name, RubyDirectedTester *_tester,
                 PortID _id)
-            : MasterPort(_name, _tester, _id), tester(_tester)
+            : RequestPort(_name, _tester, _id), tester(_tester)
         {}
 
       protected:
@@ -71,7 +71,7 @@ class RubyDirectedTester : public ClockedObject
     Port &getPort(const std::string &if_name,
                   PortID idx=InvalidPortID) override;
 
-    MasterPort* getCpuPort(int idx);
+    RequestPort* getCpuPort(int idx);
 
     void init() override;
 
@@ -98,7 +98,7 @@ class RubyDirectedTester : public ClockedObject
     RubyDirectedTester& operator=(const RubyDirectedTester& obj);
 
     uint64_t m_requests_completed;
-    std::vector<MasterPort*> ports;
+    std::vector<RequestPort*> ports;
     uint64_t m_requests_to_complete;
     DirectedGenerator* generator;
 };

--- a/src/cpu/testers/directedtest/SeriesRequestGenerator.cc
+++ b/src/cpu/testers/directedtest/SeriesRequestGenerator.cc
@@ -55,7 +55,7 @@ SeriesRequestGenerator::initiate()
     DPRINTF(DirectedTest, "initiating request\n");
     assert(m_status == SeriesRequestGeneratorStatus_Thinking);
 
-    MasterPort* port = m_directed_tester->getCpuPort(m_active_node);
+    RequestPort* port = m_directed_tester->getCpuPort(m_active_node);
 
     Request::Flags flags;
 

--- a/src/cpu/testers/garnet_synthetic_traffic/GarnetSyntheticTraffic.hh
+++ b/src/cpu/testers/garnet_synthetic_traffic/GarnetSyntheticTraffic.hh
@@ -74,14 +74,14 @@ class GarnetSyntheticTraffic : public ClockedObject
   protected:
     EventFunctionWrapper tickEvent;
 
-    class CpuPort : public MasterPort
+    class CpuPort : public RequestPort
     {
         GarnetSyntheticTraffic *tester;
 
       public:
 
         CpuPort(const std::string &_name, GarnetSyntheticTraffic *_tester)
-            : MasterPort(_name, _tester), tester(_tester)
+            : RequestPort(_name, _tester), tester(_tester)
         { }
 
       protected:

--- a/src/cpu/testers/garnet_synthetic_traffic/GarnetSyntheticTraffic.py
+++ b/src/cpu/testers/garnet_synthetic_traffic/GarnetSyntheticTraffic.py
@@ -51,5 +51,5 @@ class GarnetSyntheticTraffic(ClockedObject):
                               after decimal point")
     response_limit = Param.Cycles(5000000, "Cycles before exiting \
                                             due to lack of progress")
-    test = MasterPort("Port to the memory system to test")
+    test = RequestPort("Port to the memory system to test")
     system = Param.System(Parent.any, "System we belong to")

--- a/src/cpu/testers/memtest/MemTest.py
+++ b/src/cpu/testers/memtest/MemTest.py
@@ -64,7 +64,7 @@ class MemTest(ClockedObject):
     progress_check = Param.Cycles(5000000, "Cycles before exiting " \
                                       "due to lack of progress")
 
-    port = MasterPort("Port to the memory system")
+    port = RequestPort("Port to the memory system")
     system = Param.System(Parent.any, "System this tester is part of")
 
     # Add the ability to supress error responses on functional

--- a/src/cpu/testers/memtest/memtest.hh
+++ b/src/cpu/testers/memtest/memtest.hh
@@ -91,14 +91,14 @@ class MemTest : public ClockedObject
 
     EventFunctionWrapper noResponseEvent;
 
-    class CpuPort : public MasterPort
+    class CpuPort : public RequestPort
     {
         MemTest &memtest;
 
       public:
 
         CpuPort(const std::string &_name, MemTest &_memtest)
-            : MasterPort(_name, &_memtest), memtest(_memtest)
+            : RequestPort(_name, &_memtest), memtest(_memtest)
         { }
 
       protected:

--- a/src/cpu/testers/rubytest/Check.cc
+++ b/src/cpu/testers/rubytest/Check.cc
@@ -84,7 +84,7 @@ Check::initiatePrefetch()
     DPRINTF(RubyTest, "initiating prefetch\n");
 
     int index = random_mt.random(0, m_num_readers - 1);
-    MasterPort* port = m_tester_ptr->getReadableCpuPort(index);
+    RequestPort* port = m_tester_ptr->getReadableCpuPort(index);
 
     Request::Flags flags;
     flags.set(Request::PREFETCH);
@@ -142,7 +142,7 @@ Check::initiateFlush()
     DPRINTF(RubyTest, "initiating Flush\n");
 
     int index = random_mt.random(0, m_num_writers - 1);
-    MasterPort* port = m_tester_ptr->getWritableCpuPort(index);
+    RequestPort* port = m_tester_ptr->getWritableCpuPort(index);
 
     Request::Flags flags;
 
@@ -172,7 +172,7 @@ Check::initiateAction()
     assert(m_status == TesterStatus_Idle);
 
     int index = random_mt.random(0, m_num_writers - 1);
-    MasterPort* port = m_tester_ptr->getWritableCpuPort(index);
+    RequestPort* port = m_tester_ptr->getWritableCpuPort(index);
 
     Request::Flags flags;
 
@@ -233,7 +233,7 @@ Check::initiateCheck()
     assert(m_status == TesterStatus_Ready);
 
     int index = random_mt.random(0, m_num_readers - 1);
-    MasterPort* port = m_tester_ptr->getReadableCpuPort(index);
+    RequestPort* port = m_tester_ptr->getReadableCpuPort(index);
 
     Request::Flags flags;
 

--- a/src/cpu/testers/rubytest/RubyTester.cc
+++ b/src/cpu/testers/rubytest/RubyTester.cc
@@ -203,7 +203,7 @@ RubyTester::isInstDataCpuPort(int idx)
             (idx < (m_num_inst_only_ports + m_num_inst_data_ports)));
 }
 
-MasterPort*
+RequestPort*
 RubyTester::getReadableCpuPort(int idx)
 {
     assert(idx >= 0 && idx < readPorts.size());
@@ -211,7 +211,7 @@ RubyTester::getReadableCpuPort(int idx)
     return readPorts[idx];
 }
 
-MasterPort*
+RequestPort*
 RubyTester::getWritableCpuPort(int idx)
 {
     assert(idx >= 0 && idx < writePorts.size());

--- a/src/cpu/testers/rubytest/RubyTester.hh
+++ b/src/cpu/testers/rubytest/RubyTester.hh
@@ -57,7 +57,7 @@
 class RubyTester : public ClockedObject
 {
   public:
-    class CpuPort : public MasterPort
+    class CpuPort : public RequestPort
     {
       private:
         RubyTester *tester;
@@ -73,7 +73,7 @@ class RubyTester : public ClockedObject
 
         CpuPort(const std::string &_name, RubyTester *_tester, PortID _id,
                 PortID _index)
-            : MasterPort(_name, _tester, _id), tester(_tester),
+            : RequestPort(_name, _tester, _id), tester(_tester),
               globalIdx(_index)
         {}
 
@@ -101,8 +101,8 @@ class RubyTester : public ClockedObject
     bool isInstOnlyCpuPort(int idx);
     bool isInstDataCpuPort(int idx);
 
-    MasterPort* getReadableCpuPort(int idx);
-    MasterPort* getWritableCpuPort(int idx);
+    RequestPort* getReadableCpuPort(int idx);
+    RequestPort* getWritableCpuPort(int idx);
 
     void init() override;
 
@@ -137,8 +137,8 @@ class RubyTester : public ClockedObject
 
     int m_num_cpus;
     uint64_t m_checks_completed;
-    std::vector<MasterPort*> writePorts;
-    std::vector<MasterPort*> readPorts;
+    std::vector<RequestPort*> writePorts;
+    std::vector<RequestPort*> readPorts;
     uint64_t m_checks_to_complete;
     int m_deadlock_threshold;
     int m_num_writers;

--- a/src/cpu/testers/traffic_gen/BaseTrafficGen.py
+++ b/src/cpu/testers/traffic_gen/BaseTrafficGen.py
@@ -57,7 +57,7 @@ class BaseTrafficGen(ClockedObject):
     cxx_header = "cpu/testers/traffic_gen/traffic_gen.hh"
 
     # Port used for sending requests and receiving responses
-    port = MasterPort("Master port")
+    port = RequestPort("Master port")
 
     # System used to determine the mode of the memory system
     system = Param.System(Parent.any, "System this generator is part of")

--- a/src/cpu/testers/traffic_gen/BaseTrafficGen.py
+++ b/src/cpu/testers/traffic_gen/BaseTrafficGen.py
@@ -110,9 +110,9 @@ class BaseTrafficGen(ClockedObject):
     def connectCachedPorts(self, bus):
         if hasattr(self, '_cached_ports') and (len(self._cached_ports) > 0):
             for p in self._cached_ports:
-                exec('self.%s = bus.slave' % p)
+                exec('self.%s = bus.responder' % p)
         else:
-            self.port = bus.slave
+            self.port = bus.responder
 
     def connectAllPorts(self, cached_bus, uncached_bus = None):
         self.connectCachedPorts(cached_bus)

--- a/src/cpu/testers/traffic_gen/BaseTrafficGen.py
+++ b/src/cpu/testers/traffic_gen/BaseTrafficGen.py
@@ -110,9 +110,9 @@ class BaseTrafficGen(ClockedObject):
     def connectCachedPorts(self, bus):
         if hasattr(self, '_cached_ports') and (len(self._cached_ports) > 0):
             for p in self._cached_ports:
-                exec('self.%s = bus.responder' % p)
+                exec('self.%s = bus.slave' % p)
         else:
-            self.port = bus.responder
+            self.port = bus.slave
 
     def connectAllPorts(self, cached_bus, uncached_bus = None):
         self.connectCachedPorts(cached_bus)

--- a/src/cpu/testers/traffic_gen/base.hh
+++ b/src/cpu/testers/traffic_gen/base.hh
@@ -124,12 +124,12 @@ class BaseTrafficGen : public ClockedObject
 
 
     /** Master port specialisation for the traffic generator */
-    class TrafficGenPort : public MasterPort
+    class TrafficGenPort : public RequestPort
     {
       public:
 
         TrafficGenPort(const std::string& name, BaseTrafficGen& traffic_gen)
-            : MasterPort(name, &traffic_gen), trafficGen(traffic_gen)
+            : RequestPort(name, &traffic_gen), trafficGen(traffic_gen)
         { }
 
       protected:

--- a/src/cpu/trace/trace_cpu.hh
+++ b/src/cpu/trace/trace_cpu.hh
@@ -221,12 +221,12 @@ class TraceCPU : public BaseCPU
     /**
      * IcachePort class that interfaces with L1 Instruction Cache.
      */
-    class IcachePort : public MasterPort
+    class IcachePort : public RequestPort
     {
       public:
         /** Default constructor. */
         IcachePort(TraceCPU* _cpu)
-            : MasterPort(_cpu->name() + ".icache_port", _cpu),
+            : RequestPort(_cpu->name() + ".icache_port", _cpu),
                          owner(_cpu)
         { }
 
@@ -261,13 +261,13 @@ class TraceCPU : public BaseCPU
     /**
      * DcachePort class that interfaces with L1 Data Cache.
      */
-    class DcachePort : public MasterPort
+    class DcachePort : public RequestPort
     {
 
       public:
         /** Default constructor. */
         DcachePort(TraceCPU* _cpu)
-            : MasterPort(_cpu->name() + ".dcache_port", _cpu),
+            : RequestPort(_cpu->name() + ".dcache_port", _cpu),
                          owner(_cpu)
         { }
 
@@ -423,7 +423,7 @@ class TraceCPU : public BaseCPU
         public:
         /* Constructor */
         FixedRetryGen(TraceCPU& _owner, const std::string& _name,
-                   MasterPort& _port, MasterID master_id,
+                   RequestPort& _port, MasterID master_id,
                    const std::string& trace_file)
             : owner(_owner),
               port(_port),
@@ -501,7 +501,7 @@ class TraceCPU : public BaseCPU
         TraceCPU& owner;
 
         /** Reference of the port to be used to issue memory requests. */
-        MasterPort& port;
+        RequestPort& port;
 
         /** MasterID used for the requests being sent. */
         const MasterID masterID;
@@ -847,7 +847,7 @@ class TraceCPU : public BaseCPU
         public:
         /* Constructor */
         ElasticDataGen(TraceCPU& _owner, const std::string& _name,
-                   MasterPort& _port, MasterID master_id,
+                   RequestPort& _port, MasterID master_id,
                    const std::string& trace_file, TraceCPUParams *params)
             : owner(_owner),
               port(_port),
@@ -984,7 +984,7 @@ class TraceCPU : public BaseCPU
         TraceCPU& owner;
 
         /** Reference of the port to be used to issue memory requests. */
-        MasterPort& port;
+        RequestPort& port;
 
         /** MasterID used for the requests being sent. */
         const MasterID masterID;

--- a/src/gpu-compute/GPU.py
+++ b/src/gpu-compute/GPU.py
@@ -161,10 +161,10 @@ class ComputeUnit(ClockedObject):
 
     memory_port = VectorMasterPort("Port to the memory system")
     translation_port = VectorMasterPort('Port to the TLB hierarchy')
-    sqc_port = MasterPort("Port to the SQC (I-cache")
-    sqc_tlb_port = MasterPort("Port to the TLB for the SQC (I-cache)")
-    scalar_port = MasterPort("Port to the scalar data cache")
-    scalar_tlb_port = MasterPort("Port to the TLB for the scalar data cache")
+    sqc_port = RequestPort("Port to the SQC (I-cache")
+    sqc_tlb_port = RequestPort("Port to the TLB for the SQC (I-cache)")
+    scalar_port = RequestPort("Port to the scalar data cache")
+    scalar_tlb_port = RequestPort("Port to the TLB for the scalar data cache")
     perLaneTLB = Param.Bool(False, "enable per-lane TLB")
     prefetch_depth = Param.Int(0, "Number of prefetches triggered at a time"\
                                "(0 turns off prefetching)")
@@ -192,7 +192,7 @@ class ComputeUnit(ClockedObject):
     max_cu_tokens = Param.Int(4, "Maximum number of tokens, i.e., the number"\
                             " of instructions that can be sent to coalescer")
     ldsBus = Bridge() # the bridge between the CU and its LDS
-    ldsPort = MasterPort("The port that goes to the LDS")
+    ldsPort = RequestPort("The port that goes to the LDS")
     localDataStore = Param.LdsState("the LDS for this CU")
 
     vector_register_file = VectorParam.VectorRegisterFile("Vector register "\

--- a/src/gpu-compute/LdsState.py
+++ b/src/gpu-compute/LdsState.py
@@ -44,4 +44,4 @@ class LdsState(ClockedObject):
     bankConflictPenalty = Param.Int(1, 'penalty per LDS bank conflict when '\
                                     'accessing data')
     banks = Param.Int(32, 'Number of LDS banks')
-    cuPort = SlavePort("port that goes to the compute unit")
+    cuPort = ResponsePort("port that goes to the compute unit")

--- a/src/gpu-compute/X86GPUTLB.py
+++ b/src/gpu-compute/X86GPUTLB.py
@@ -40,7 +40,7 @@ if buildEnv['FULL_SYSTEM']:
     class X86PagetableWalker(SimObject):
         type = 'X86PagetableWalker'
         cxx_class = 'X86ISA::Walker'
-        port = SlavePort("Port for the hardware table walker")
+        port = ResponsePort("Port for the hardware table walker")
         system = Param.System(Parent.any, "system object")
 
 class X86GPUTLB(ClockedObject):

--- a/src/gpu-compute/compute_unit.cc
+++ b/src/gpu-compute/compute_unit.cc
@@ -2593,7 +2593,7 @@ ComputeUnit::LDSPort::sendTimingReq(PacketPtr pkt)
                         computeUnit->cu_id, gpuDynInst->simdId,
                         gpuDynInst->wfSlotId);
         return false;
-    } else if (!MasterPort::sendTimingReq(pkt)) {
+    } else if (!RequestPort::sendTimingReq(pkt)) {
         // need to stall the LDS port until a recvReqRetry() is received
         // this indicates that there is more space
         stallPort();
@@ -2637,7 +2637,7 @@ ComputeUnit::LDSPort::recvReqRetry()
 
         DPRINTF(GPUPort, "CU%d: retrying LDS send\n", computeUnit->cu_id);
 
-        if (!MasterPort::sendTimingReq(packet)) {
+        if (!RequestPort::sendTimingReq(packet)) {
             // Stall port
             stallPort();
             DPRINTF(GPUPort, ": LDS send failed again\n");

--- a/src/gpu-compute/compute_unit.hh
+++ b/src/gpu-compute/compute_unit.hh
@@ -671,11 +671,11 @@ class ComputeUnit : public ClockedObject
     GMTokenPort gmTokenPort;
 
     /** Data access Port **/
-    class DataPort : public MasterPort
+    class DataPort : public RequestPort
     {
       public:
         DataPort(const std::string &_name, ComputeUnit *_cu, PortID _index)
-            : MasterPort(_name, _cu), computeUnit(_cu),
+            : RequestPort(_name, _cu), computeUnit(_cu),
               index(_index) { }
 
         bool snoopRangeSent;
@@ -721,12 +721,12 @@ class ComputeUnit : public ClockedObject
     };
 
     // Scalar data cache access port
-    class ScalarDataPort : public MasterPort
+    class ScalarDataPort : public RequestPort
     {
       public:
         ScalarDataPort(const std::string &_name, ComputeUnit *_cu,
                        PortID _index)
-            : MasterPort(_name, _cu, _index), computeUnit(_cu), index(_index)
+            : RequestPort(_name, _cu, _index), computeUnit(_cu), index(_index)
         {
             (void)index;
         }
@@ -771,11 +771,11 @@ class ComputeUnit : public ClockedObject
     };
 
     // Instruction cache access port
-    class SQCPort : public MasterPort
+    class SQCPort : public RequestPort
     {
       public:
         SQCPort(const std::string &_name, ComputeUnit *_cu, PortID _index)
-            : MasterPort(_name, _cu), computeUnit(_cu),
+            : RequestPort(_name, _cu), computeUnit(_cu),
               index(_index) { }
 
         bool snoopRangeSent;
@@ -814,11 +814,11 @@ class ComputeUnit : public ClockedObject
      };
 
     /** Data TLB port **/
-    class DTLBPort : public MasterPort
+    class DTLBPort : public RequestPort
     {
       public:
         DTLBPort(const std::string &_name, ComputeUnit *_cu, PortID _index)
-            : MasterPort(_name, _cu), computeUnit(_cu),
+            : RequestPort(_name, _cu), computeUnit(_cu),
               index(_index), stalled(false)
         { }
 
@@ -862,11 +862,11 @@ class ComputeUnit : public ClockedObject
         virtual void recvReqRetry();
     };
 
-    class ScalarDTLBPort : public MasterPort
+    class ScalarDTLBPort : public RequestPort
     {
       public:
         ScalarDTLBPort(const std::string &_name, ComputeUnit *_cu)
-            : MasterPort(_name, _cu), computeUnit(_cu), stalled(false)
+            : RequestPort(_name, _cu), computeUnit(_cu), stalled(false)
         {
         }
 
@@ -890,11 +890,11 @@ class ComputeUnit : public ClockedObject
         bool stalled;
     };
 
-    class ITLBPort : public MasterPort
+    class ITLBPort : public RequestPort
     {
       public:
         ITLBPort(const std::string &_name, ComputeUnit *_cu)
-            : MasterPort(_name, _cu), computeUnit(_cu), stalled(false) { }
+            : RequestPort(_name, _cu), computeUnit(_cu), stalled(false) { }
 
 
         bool isStalled() { return stalled; }
@@ -932,11 +932,11 @@ class ComputeUnit : public ClockedObject
     /**
      * the port intended to communicate between the CU and its LDS
      */
-    class LDSPort : public MasterPort
+    class LDSPort : public RequestPort
     {
       public:
         LDSPort(const std::string &_name, ComputeUnit *_cu, PortID _id)
-        : MasterPort(_name, _cu, _id), computeUnit(_cu)
+        : RequestPort(_name, _cu, _id), computeUnit(_cu)
         {
         }
 

--- a/src/gpu-compute/gpu_tlb.hh
+++ b/src/gpu-compute/gpu_tlb.hh
@@ -236,12 +236,12 @@ namespace X86ISA
         void issueTLBLookup(PacketPtr pkt);
 
         // CpuSidePort is the TLB Port closer to the CPU/CU side
-        class CpuSidePort : public SlavePort
+        class CpuSidePort : public ResponsePort
         {
           public:
             CpuSidePort(const std::string &_name, GpuTLB * gpu_TLB,
                         PortID _index)
-                : SlavePort(_name, gpu_TLB), tlb(gpu_TLB), index(_index) { }
+                : ResponsePort(_name, gpu_TLB), tlb(gpu_TLB), index(_index) { }
 
           protected:
             GpuTLB *tlb;
@@ -263,12 +263,12 @@ namespace X86ISA
          * Future action item: if we ever do real page walks, then this port
          * should be connected to a RubyPort.
          */
-        class MemSidePort : public MasterPort
+        class MemSidePort : public RequestPort
         {
           public:
             MemSidePort(const std::string &_name, GpuTLB * gpu_TLB,
                         PortID _index)
-                : MasterPort(_name, gpu_TLB), tlb(gpu_TLB), index(_index) { }
+                : RequestPort(_name, gpu_TLB), tlb(gpu_TLB), index(_index) { }
 
             std::deque<PacketPtr> retries;
 
@@ -325,7 +325,7 @@ namespace X86ISA
             // When was the req for this translation issued
             uint64_t issueTime;
             // Remember where this came from
-            std::vector<SlavePort*>ports;
+            std::vector<ResponsePort*>ports;
 
             // keep track of #uncoalesced reqs per packet per TLB level;
             // reqCnt per level >= reqCnt higher level

--- a/src/gpu-compute/lds_state.hh
+++ b/src/gpu-compute/lds_state.hh
@@ -157,11 +157,11 @@ class LdsState: public ClockedObject
     /**
      * CuSidePort is the LDS Port closer to the CU side
      */
-    class CuSidePort: public SlavePort
+    class CuSidePort: public ResponsePort
     {
       public:
         CuSidePort(const std::string &_name, LdsState *_ownerLds) :
-                SlavePort(_name, _ownerLds), ownerLds(_ownerLds)
+                ResponsePort(_name, _ownerLds), ownerLds(_ownerLds)
         {
         }
 

--- a/src/gpu-compute/tlb_coalescer.cc
+++ b/src/gpu-compute/tlb_coalescer.cc
@@ -198,7 +198,7 @@ TLBCoalescer::updatePhysAddresses(PacketPtr pkt)
             sender_state->hitLevel = first_hit_level;
         }
 
-        SlavePort *return_port = sender_state->ports.back();
+        ResponsePort *return_port = sender_state->ports.back();
         sender_state->ports.pop_back();
 
         // Translation is done - Convert to a response pkt if necessary and

--- a/src/gpu-compute/tlb_coalescer.hh
+++ b/src/gpu-compute/tlb_coalescer.hh
@@ -137,12 +137,12 @@ class TLBCoalescer : public ClockedObject
     void updatePhysAddresses(PacketPtr pkt);
     void regStats() override;
 
-    class CpuSidePort : public SlavePort
+    class CpuSidePort : public ResponsePort
     {
       public:
         CpuSidePort(const std::string &_name, TLBCoalescer *tlb_coalescer,
                     PortID _index)
-            : SlavePort(_name, tlb_coalescer), coalescer(tlb_coalescer),
+            : ResponsePort(_name, tlb_coalescer), coalescer(tlb_coalescer),
               index(_index) { }
 
       protected:
@@ -165,12 +165,12 @@ class TLBCoalescer : public ClockedObject
         virtual AddrRangeList getAddrRanges() const;
     };
 
-    class MemSidePort : public MasterPort
+    class MemSidePort : public RequestPort
     {
       public:
         MemSidePort(const std::string &_name, TLBCoalescer *tlb_coalescer,
                     PortID _index)
-            : MasterPort(_name, tlb_coalescer), coalescer(tlb_coalescer),
+            : RequestPort(_name, tlb_coalescer), coalescer(tlb_coalescer),
               index(_index) { }
 
         std::deque<PacketPtr> retries;

--- a/src/learning_gem5/part2/SimpleCache.py
+++ b/src/learning_gem5/part2/SimpleCache.py
@@ -36,7 +36,7 @@ class SimpleCache(ClockedObject):
     # Vector port example. Both the instruction and data ports connect to this
     # port which is automatically split out into two ports.
     cpu_side = VectorSlavePort("CPU side port, receives requests")
-    mem_side = MasterPort("Memory side port, sends requests")
+    mem_side = RequestPort("Memory side port, sends requests")
 
     latency = Param.Cycles(1, "Cycles taken on a hit or to resolve a miss")
 

--- a/src/learning_gem5/part2/simple_cache.hh
+++ b/src/learning_gem5/part2/simple_cache.hh
@@ -51,7 +51,7 @@ class SimpleCache : public ClockedObject
      * Port on the CPU-side that receives requests.
      * Mostly just forwards requests to the cache (owner)
      */
-    class CPUSidePort : public SlavePort
+    class CPUSidePort : public ResponsePort
     {
       private:
         /// Since this is a vector port, need to know what number this one is
@@ -71,7 +71,7 @@ class SimpleCache : public ClockedObject
          * Constructor. Just calls the superclass constructor.
          */
         CPUSidePort(const std::string& name, int id, SimpleCache *owner) :
-            SlavePort(name, owner), id(id), owner(owner), needRetry(false),
+            ResponsePort(name, owner), id(id), owner(owner), needRetry(false),
             blockedPacket(nullptr)
         { }
 
@@ -137,7 +137,7 @@ class SimpleCache : public ClockedObject
      * Port on the memory-side that receives responses.
      * Mostly just forwards requests to the cache (owner)
      */
-    class MemSidePort : public MasterPort
+    class MemSidePort : public RequestPort
     {
       private:
         /// The object that owns this object (SimpleCache)
@@ -151,7 +151,7 @@ class SimpleCache : public ClockedObject
          * Constructor. Just calls the superclass constructor.
          */
         MemSidePort(const std::string& name, SimpleCache *owner) :
-            MasterPort(name, owner), owner(owner), blockedPacket(nullptr)
+            RequestPort(name, owner), owner(owner), blockedPacket(nullptr)
         { }
 
         /**

--- a/src/learning_gem5/part2/simple_memobj.hh
+++ b/src/learning_gem5/part2/simple_memobj.hh
@@ -48,7 +48,7 @@ class SimpleMemobj : public SimObject
      * Mostly just forwards requests to the owner.
      * Part of a vector of ports. One for each CPU port (e.g., data, inst)
      */
-    class CPUSidePort : public SlavePort
+    class CPUSidePort : public ResponsePort
     {
       private:
         /// The object that owns this object (SimpleMemobj)
@@ -65,7 +65,7 @@ class SimpleMemobj : public SimObject
          * Constructor. Just calls the superclass constructor.
          */
         CPUSidePort(const std::string& name, SimpleMemobj *owner) :
-            SlavePort(name, owner), owner(owner), needRetry(false),
+            ResponsePort(name, owner), owner(owner), needRetry(false),
             blockedPacket(nullptr)
         { }
 
@@ -79,7 +79,7 @@ class SimpleMemobj : public SimObject
 
         /**
          * Get a list of the non-overlapping address ranges the owner is
-         * responsible for. All slave ports must override this function
+         * responsible for. All response ports must override this function
          * and return a populated list with at least one item.
          *
          * @return a list of ranges responded to
@@ -94,14 +94,14 @@ class SimpleMemobj : public SimObject
 
       protected:
         /**
-         * Receive an atomic request packet from the master port.
+         * Receive an atomic request packet from the request port.
          * No need to implement in this simple memobj.
          */
         Tick recvAtomic(PacketPtr pkt) override
         { panic("recvAtomic unimpl."); }
 
         /**
-         * Receive a functional request packet from the master port.
+         * Receive a functional request packet from the request port.
          * Performs a "debug" access updating/reading the data in place.
          *
          * @param packet the requestor sent.
@@ -109,7 +109,7 @@ class SimpleMemobj : public SimObject
         void recvFunctional(PacketPtr pkt) override;
 
         /**
-         * Receive a timing request from the master port.
+         * Receive a timing request from the request port.
          *
          * @param the packet that the requestor sent
          * @return whether this object can consume the packet. If false, we
@@ -119,8 +119,8 @@ class SimpleMemobj : public SimObject
         bool recvTimingReq(PacketPtr pkt) override;
 
         /**
-         * Called by the master port if sendTimingResp was called on this
-         * slave port (causing recvTimingResp to be called on the master
+         * Called by the request port if sendTimingResp was called on this
+         * response port (causing recvTimingResp to be called on the request
          * port) and was unsuccesful.
          */
         void recvRespRetry() override;
@@ -130,7 +130,7 @@ class SimpleMemobj : public SimObject
      * Port on the memory-side that receives responses.
      * Mostly just forwards requests to the owner
      */
-    class MemSidePort : public MasterPort
+    class MemSidePort : public RequestPort
     {
       private:
         /// The object that owns this object (SimpleMemobj)
@@ -144,7 +144,7 @@ class SimpleMemobj : public SimObject
          * Constructor. Just calls the superclass constructor.
          */
         MemSidePort(const std::string& name, SimpleMemobj *owner) :
-            MasterPort(name, owner), owner(owner), blockedPacket(nullptr)
+            RequestPort(name, owner), owner(owner), blockedPacket(nullptr)
         { }
 
         /**
@@ -157,19 +157,19 @@ class SimpleMemobj : public SimObject
 
       protected:
         /**
-         * Receive a timing response from the slave port.
+         * Receive a timing response from the response port.
          */
         bool recvTimingResp(PacketPtr pkt) override;
 
         /**
-         * Called by the slave port if sendTimingReq was called on this
-         * master port (causing recvTimingReq to be called on the slave
+         * Called by the response port if sendTimingReq was called on this
+         * request port (causing recvTimingReq to be called on the response
          * port) and was unsuccesful.
          */
         void recvReqRetry() override;
 
         /**
-         * Called to receive an address range change from the peer slave
+         * Called to receive an address range change from the peer response
          * port. The default implementation ignores the change and does
          * nothing. Override this function in a derived class if the owner
          * needs to be aware of the address ranges, e.g. in an

--- a/src/learning_gem5/part2/simple_memobj.hh
+++ b/src/learning_gem5/part2/simple_memobj.hh
@@ -163,13 +163,13 @@ class SimpleMemobj : public SimObject
 
         /**
          * Called by the response port if sendTimingReq was called on this
-         * request port (causing recvTimingReq to be called on the response
+         * request port (causing recvTimingReq to be called on the responder
          * port) and was unsuccesful.
          */
         void recvReqRetry() override;
 
         /**
-         * Called to receive an address range change from the peer response
+         * Called to receive an address range change from the peer responder
          * port. The default implementation ignores the change and does
          * nothing. Override this function in a derived class if the owner
          * needs to be aware of the address ranges, e.g. in an

--- a/src/mem/port.cc
+++ b/src/mem/port.cc
@@ -131,7 +131,7 @@ RequestPort::bind(Port &peer)
     _responsePort = response_port;
     Port::bind(peer);
     // response port also keeps track of request port
-    _responsePort->slaveBind(*this);
+    _responsePort->responderBind(*this);
 }
 
 void
@@ -139,7 +139,7 @@ RequestPort::unbind()
 {
     panic_if(!isConnected(), "Can't unbind request port %s which is "
     "not bound.", name());
-    _responsePort->slaveUnbind();
+    _responsePort->responderUnbind();
     _responsePort = &defaultResponsePort;
     Port::unbind();
 }
@@ -164,7 +164,7 @@ RequestPort::printAddr(Addr a)
 }
 
 /**
- * Slave port
+ * Response port
  */
 ResponsePort::ResponsePort(const std::string& name, SimObject* _owner,
     PortID id) : Port(name, id), _requestPort(&defaultRequestPort),
@@ -177,14 +177,14 @@ ResponsePort::~ResponsePort()
 }
 
 void
-ResponsePort::slaveUnbind()
+ResponsePort::responderUnbind()
 {
     _requestPort = &defaultRequestPort;
     Port::unbind();
 }
 
 void
-ResponsePort::slaveBind(RequestPort& request_port)
+ResponsePort::responderBind(RequestPort& request_port)
 {
     _requestPort = &request_port;
     Port::bind(request_port);

--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -422,13 +422,13 @@ class ResponsePort : public Port, public AtomicResponseProtocol,
      * Called by the requestor port to unbind. Should never be called
      * directly.
      */
-    void slaveUnbind();
+    void responderUnbind();
 
     /**
      * Called by the requestor port to bind. Should never be called
      * directly.
      */
-    void slaveBind(RequestPort& request_port);
+    void responderBind(RequestPort& request_port);
 
     /**
      * Default implementations.

--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -450,8 +450,8 @@ class ResponsePort : public Port, public AtomicResponseProtocol,
 
 class M5_DEPRECATED SlavePort : public ResponsePort
 {
-    public:
-        SlavePort(const std::string& name, SimObject* _owner,
+  public:
+    SlavePort(const std::string& name, SimObject* _owner,
               PortID id=InvalidPortID) : ResponsePort(name, _owner, id){}
 };
 

--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -56,10 +56,13 @@
 class SimObject;
 
 /** Forward declaration */
+class MasterPort;
 class SlavePort;
 
+class ResponsePort;
+
 /**
- * A MasterPort is a specialisation of a BaseMasterPort, which
+ * A RequestPort is a specialisation of a Port, which
  * implements the default protocol for the three different level of
  * transport functions. In addition to the basic functionality of
  * sending packets, it also has functions to receive range changes or
@@ -68,37 +71,37 @@ class SlavePort;
  * The three protocols are atomic, timing, and functional, each with its own
  * header file.
  */
-class MasterPort : public Port, public AtomicRequestProtocol,
+class RequestPort: public Port, public AtomicRequestProtocol,
     public TimingRequestProtocol, public FunctionalRequestProtocol
 {
-    friend class SlavePort;
+    friend class ResponsePort;
 
-  private:
-    SlavePort *_slavePort;
+    private:
+    ResponsePort *_responsePort;
 
   protected:
     SimObject &owner;
 
   public:
-    MasterPort(const std::string& name, SimObject* _owner,
+    RequestPort(const std::string& name, SimObject* _owner,
                PortID id=InvalidPortID);
-    virtual ~MasterPort();
+    virtual ~RequestPort();
 
     /**
-     * Bind this master port to a slave port. This also does the
-     * mirror action and binds the slave port to the master port.
+     * Bind this request port to a response port. This also does the
+     * mirror action and binds the responder port to the requestor port.
      */
     void bind(Port &peer) override;
 
     /**
-     * Unbind this master port and the associated slave port.
+     * Unbind this requestor port and the associated responder port.
      */
     void unbind() override;
 
     /**
-     * Determine if this master port is snooping or not. The default
+     * Determine if this requestor port is snooping or not. The default
      * implementation returns false and thus tells the neighbour we
-     * are not snooping. Any master port that wants to receive snoop
+     * are not snooping. Any requestor port that wants to receive snoop
      * requests (e.g. a cache connected to a bus) has to override this
      * function.
      *
@@ -107,7 +110,7 @@ class MasterPort : public Port, public AtomicRequestProtocol,
     virtual bool isSnooping() const { return false; }
 
     /**
-     * Get the address ranges of the connected slave port.
+     * Get the address ranges of the connected responder port.
      */
     AddrRangeList getAddrRanges() const;
 
@@ -159,7 +162,7 @@ class MasterPort : public Port, public AtomicRequestProtocol,
     /* The timing protocol. */
 
     /**
-     * Attempt to send a timing request to the slave port by calling
+     * Attempt to send a timing request to the responder port by calling
      * its corresponding receive function. If the send does not
      * succeed, as indicated by the return value, then the sender must
      * wait for a recvReqRetry at which point it can re-issue a
@@ -172,7 +175,7 @@ class MasterPort : public Port, public AtomicRequestProtocol,
     bool sendTimingReq(PacketPtr pkt);
 
     /**
-     * Check if the slave can handle a timing request.
+     * Check if the responder can handle a timing request.
      *
      * If the send cannot be handled at the moment, as indicated by
      * the return value, then the sender will receive a recvReqRetry
@@ -185,7 +188,7 @@ class MasterPort : public Port, public AtomicRequestProtocol,
     bool tryTiming(PacketPtr pkt) const;
 
     /**
-     * Attempt to send a timing snoop response packet to the slave
+     * Attempt to send a timing snoop response packet to the responder
      * port by calling its corresponding receive function. If the send
      * does not succeed, as indicated by the return value, then the
      * sender must wait for a recvRetrySnoop at which point it can
@@ -196,8 +199,8 @@ class MasterPort : public Port, public AtomicRequestProtocol,
     bool sendTimingSnoopResp(PacketPtr pkt);
 
     /**
-     * Send a retry to the slave port that previously attempted a
-     * sendTimingResp to this master port and failed. Note that this
+     * Send a retry to the responder port that previously attempted a
+     * sendTimingResp to this requestor port and failed. Note that this
      * is virtual so that the "fake" snoop response port in the
      * coherent crossbar can override the behaviour.
      */
@@ -205,7 +208,7 @@ class MasterPort : public Port, public AtomicRequestProtocol,
 
   protected:
     /**
-     * Called to receive an address range change from the peer slave
+     * Called to receive an address range change from the peer responder
      * port. The default implementation ignores the change and does
      * nothing. Override this function in a derived class if the owner
      * needs to be aware of the address ranges, e.g. in an
@@ -242,22 +245,29 @@ class MasterPort : public Port, public AtomicRequestProtocol,
     }
 };
 
+class M5_DEPRECATED MasterPort : public RequestPort
+{
+    public:
+        MasterPort(const std::string& name, SimObject* _owner,
+               PortID id=InvalidPortID) : RequestPort(name, _owner, id) {}
+};
+
 /**
- * A SlavePort is a specialisation of a port. In addition to the
- * basic functionality of sending packets to its master peer, it also
- * has functions specific to a slave, e.g. to send range changes
+ * A ResponsePort is a specialisation of a port. In addition to the
+ * basic functionality of sending packets to its requestor peer, it also
+ * has functions specific to a responder, e.g. to send range changes
  * and get the address ranges that the port responds to.
  *
  * The three protocols are atomic, timing, and functional, each with its own
  * header file.
  */
-class SlavePort : public Port, public AtomicResponseProtocol,
+class ResponsePort : public Port, public AtomicResponseProtocol,
     public TimingResponseProtocol, public FunctionalResponseProtocol
 {
-    friend class MasterPort;
+    friend class RequestPort;
 
   private:
-    MasterPort* _masterPort;
+    RequestPort* _requestPort;
 
     bool defaultBackdoorWarned;
 
@@ -265,25 +275,25 @@ class SlavePort : public Port, public AtomicResponseProtocol,
     SimObject& owner;
 
   public:
-    SlavePort(const std::string& name, SimObject* _owner,
+    ResponsePort(const std::string& name, SimObject* _owner,
               PortID id=InvalidPortID);
-    virtual ~SlavePort();
+    virtual ~ResponsePort();
 
     /**
-     * Find out if the peer master port is snooping or not.
+     * Find out if the peer requestor port is snooping or not.
      *
-     * @return true if the peer master port is snooping
+     * @return true if the peer requestor port is snooping
      */
-    bool isSnooping() const { return _masterPort->isSnooping(); }
+    bool isSnooping() const { return _requestPort->isSnooping(); }
 
     /**
      * Called by the owner to send a range change
      */
-    void sendRangeChange() const { _masterPort->recvRangeChange(); }
+    void sendRangeChange() const { _requestPort->recvRangeChange(); }
 
     /**
      * Get a list of the non-overlapping address ranges the owner is
-     * responsible for. All slave ports must override this function
+     * responsible for. All response ports must override this function
      * and return a populated list with at least one item.
      *
      * @return a list of ranges responded to
@@ -291,7 +301,7 @@ class SlavePort : public Port, public AtomicResponseProtocol,
     virtual AddrRangeList getAddrRanges() const = 0;
 
     /**
-     * We let the master port do the work, so these don't do anything.
+     * We let the requestor port do the work, so these don't do anything.
      */
     void unbind() override {}
     void bind(Port &peer) override {}
@@ -312,7 +322,7 @@ class SlavePort : public Port, public AtomicResponseProtocol,
     sendAtomicSnoop(PacketPtr pkt)
     {
         try {
-            return AtomicResponseProtocol::sendSnoop(_masterPort, pkt);
+            return AtomicResponseProtocol::sendSnoop(_requestPort, pkt);
         } catch (UnboundPortException) {
             reportUnbound();
         }
@@ -332,7 +342,7 @@ class SlavePort : public Port, public AtomicResponseProtocol,
     sendFunctionalSnoop(PacketPtr pkt) const
     {
         try {
-            FunctionalResponseProtocol::sendSnoop(_masterPort, pkt);
+            FunctionalResponseProtocol::sendSnoop(_requestPort, pkt);
         } catch (UnboundPortException) {
             reportUnbound();
         }
@@ -342,7 +352,7 @@ class SlavePort : public Port, public AtomicResponseProtocol,
     /* The timing protocol. */
 
     /**
-     * Attempt to send a timing response to the master port by calling
+     * Attempt to send a timing response to the requestor port by calling
      * its corresponding receive function. If the send does not
      * succeed, as indicated by the return value, then the sender must
      * wait for a recvRespRetry at which point it can re-issue a
@@ -356,14 +366,14 @@ class SlavePort : public Port, public AtomicResponseProtocol,
     sendTimingResp(PacketPtr pkt)
     {
         try {
-            return TimingResponseProtocol::sendResp(_masterPort, pkt);
+            return TimingResponseProtocol::sendResp(_requestPort, pkt);
         } catch (UnboundPortException) {
             reportUnbound();
         }
     }
 
     /**
-     * Attempt to send a timing snoop request packet to the master port
+     * Attempt to send a timing snoop request packet to the requestor port
      * by calling its corresponding receive function. Snoop requests
      * always succeed and hence no return value is needed.
      *
@@ -373,35 +383,35 @@ class SlavePort : public Port, public AtomicResponseProtocol,
     sendTimingSnoopReq(PacketPtr pkt)
     {
         try {
-            TimingResponseProtocol::sendSnoopReq(_masterPort, pkt);
+            TimingResponseProtocol::sendSnoopReq(_requestPort, pkt);
         } catch (UnboundPortException) {
             reportUnbound();
         }
     }
 
     /**
-     * Send a retry to the master port that previously attempted a
-     * sendTimingReq to this slave port and failed.
+     * Send a retry to the requestor port that previously attempted a
+     * sendTimingReq to this response port and failed.
      */
     void
     sendRetryReq()
     {
         try {
-            TimingResponseProtocol::sendRetryReq(_masterPort);
+            TimingResponseProtocol::sendRetryReq(_requestPort);
         } catch (UnboundPortException) {
             reportUnbound();
         }
     }
 
     /**
-     * Send a retry to the master port that previously attempted a
-     * sendTimingSnoopResp to this slave port and failed.
+     * Send a retry to the requestor port that previously attempted a
+     * sendTimingSnoopResp to this response port and failed.
      */
     void
     sendRetrySnoopResp()
     {
         try {
-            TimingResponseProtocol::sendRetrySnoopResp(_masterPort);
+            TimingResponseProtocol::sendRetrySnoopResp(_requestPort);
         } catch (UnboundPortException) {
             reportUnbound();
         }
@@ -409,16 +419,16 @@ class SlavePort : public Port, public AtomicResponseProtocol,
 
   protected:
     /**
-     * Called by the master port to unbind. Should never be called
+     * Called by the requestor port to unbind. Should never be called
      * directly.
      */
     void slaveUnbind();
 
     /**
-     * Called by the master port to bind. Should never be called
+     * Called by the requestor port to bind. Should never be called
      * directly.
      */
-    void slaveBind(MasterPort& master_port);
+    void slaveBind(RequestPort& request_port);
 
     /**
      * Default implementations.
@@ -438,71 +448,79 @@ class SlavePort : public Port, public AtomicResponseProtocol,
     }
 };
 
+class M5_DEPRECATED SlavePort : public ResponsePort
+{
+    public:
+        SlavePort(const std::string& name, SimObject* _owner,
+              PortID id=InvalidPortID) : ResponsePort(name, _owner, id){}
+};
+
 inline Tick
-MasterPort::sendAtomic(PacketPtr pkt)
+RequestPort::sendAtomic(PacketPtr pkt)
 {
     try {
-        return AtomicRequestProtocol::send(_slavePort, pkt);
+        return AtomicRequestProtocol::send(_responsePort, pkt);
     } catch (UnboundPortException) {
         reportUnbound();
     }
 }
 
 inline Tick
-MasterPort::sendAtomicBackdoor(PacketPtr pkt, MemBackdoorPtr &backdoor)
+RequestPort::sendAtomicBackdoor(PacketPtr pkt, MemBackdoorPtr &backdoor)
 {
     try {
-        return AtomicRequestProtocol::sendBackdoor(_slavePort, pkt, backdoor);
+        return AtomicRequestProtocol::sendBackdoor(_responsePort,
+                                                    pkt, backdoor);
     } catch (UnboundPortException) {
         reportUnbound();
     }
 }
 
 inline void
-MasterPort::sendFunctional(PacketPtr pkt) const
+RequestPort::sendFunctional(PacketPtr pkt) const
 {
     try {
-        return FunctionalRequestProtocol::send(_slavePort, pkt);
+        return FunctionalRequestProtocol::send(_responsePort, pkt);
     } catch (UnboundPortException) {
         reportUnbound();
     }
 }
 
 inline bool
-MasterPort::sendTimingReq(PacketPtr pkt)
+RequestPort::sendTimingReq(PacketPtr pkt)
 {
     try {
-        return TimingRequestProtocol::sendReq(_slavePort, pkt);
+        return TimingRequestProtocol::sendReq(_responsePort, pkt);
     } catch (UnboundPortException) {
         reportUnbound();
     }
 }
 
 inline bool
-MasterPort::tryTiming(PacketPtr pkt) const
+RequestPort::tryTiming(PacketPtr pkt) const
 {
     try {
-        return TimingRequestProtocol::trySend(_slavePort, pkt);
+        return TimingRequestProtocol::trySend(_responsePort, pkt);
     } catch (UnboundPortException) {
         reportUnbound();
     }
 }
 
 inline bool
-MasterPort::sendTimingSnoopResp(PacketPtr pkt)
+RequestPort::sendTimingSnoopResp(PacketPtr pkt)
 {
     try {
-        return TimingRequestProtocol::sendSnoopResp(_slavePort, pkt);
+        return TimingRequestProtocol::sendSnoopResp(_responsePort, pkt);
     } catch (UnboundPortException) {
         reportUnbound();
     }
 }
 
 inline void
-MasterPort::sendRetryResp()
+RequestPort::sendRetryResp()
 {
     try {
-        TimingRequestProtocol::sendRetryResp(_slavePort);
+        TimingRequestProtocol::sendRetryResp(_responsePort);
     } catch (UnboundPortException) {
         reportUnbound();
     }

--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -76,7 +76,7 @@ class RequestPort: public Port, public AtomicRequestProtocol,
 {
     friend class ResponsePort;
 
-    private:
+  private:
     ResponsePort *_responsePort;
 
   protected:
@@ -247,8 +247,8 @@ class RequestPort: public Port, public AtomicRequestProtocol,
 
 class M5_DEPRECATED MasterPort : public RequestPort
 {
-    public:
-        MasterPort(const std::string& name, SimObject* _owner,
+  public:
+    MasterPort(const std::string& name, SimObject* _owner,
                PortID id=InvalidPortID) : RequestPort(name, _owner, id) {}
 };
 

--- a/src/mem/snoop_filter.cc
+++ b/src/mem/snoop_filter.cc
@@ -61,7 +61,7 @@ SnoopFilter::eraseIfNullEntry(SnoopFilterCache::iterator& sf_it)
 }
 
 std::pair<SnoopFilter::SnoopList, Cycles>
-SnoopFilter::lookupRequest(const Packet* cpkt, const SlavePort& slave_port)
+SnoopFilter::lookupRequest(const Packet* cpkt, const ResponsePort& slave_port)
 {
     DPRINTF(SnoopFilter, "%s: src %s packet %s\n", __func__,
             slave_port.name(), cpkt->print());
@@ -240,8 +240,8 @@ SnoopFilter::lookupSnoop(const Packet* cpkt)
 
 void
 SnoopFilter::updateSnoopResponse(const Packet* cpkt,
-                                 const SlavePort& rsp_port,
-                                 const SlavePort& req_port)
+                                 const ResponsePort& rsp_port,
+                                 const ResponsePort& req_port)
 {
     DPRINTF(SnoopFilter, "%s: rsp %s req %s packet %s\n",
             __func__, rsp_port.name(), req_port.name(), cpkt->print());
@@ -297,7 +297,7 @@ SnoopFilter::updateSnoopResponse(const Packet* cpkt,
 
 void
 SnoopFilter::updateSnoopForward(const Packet* cpkt,
-        const SlavePort& rsp_port, const MasterPort& req_port)
+        const ResponsePort& rsp_port, const RequestPort& req_port)
 {
     DPRINTF(SnoopFilter, "%s: rsp %s req %s packet %s\n",
             __func__, rsp_port.name(), req_port.name(), cpkt->print());
@@ -333,7 +333,7 @@ SnoopFilter::updateSnoopForward(const Packet* cpkt,
 }
 
 void
-SnoopFilter::updateResponse(const Packet* cpkt, const SlavePort& slave_port)
+SnoopFilter::updateResponse(const Packet* cpkt, const ResponsePort& slave_port)
 {
     DPRINTF(SnoopFilter, "%s: src %s packet %s\n",
             __func__, slave_port.name(), cpkt->print());

--- a/src/mem/snoop_filter.hh
+++ b/src/mem/snoop_filter.hh
@@ -135,7 +135,7 @@ class SnoopFilter : public SimObject {
      * @return Pair of a vector of snoop target ports and lookup latency.
      */
     std::pair<SnoopList, Cycles> lookupRequest(const Packet* cpkt,
-                                               const SlavePort& slave_port);
+                                               const ResponsePort& slave_port);
 
     /**
      * For an un-successful request, revert the change to the snoop
@@ -154,8 +154,8 @@ class SnoopFilter : public SimObject {
      * additional steering thanks to the snoop filter.
      *
      * @param cpkt Pointer to const Packet containing the snoop.
-     * @return Pair with a vector of SlavePorts that need snooping and a lookup
-     *         latency.
+     * @return Pair with a vector of ResponsePorts that need snooping and a
+     * lookup latency.
      */
     std::pair<SnoopList, Cycles> lookupSnoop(const Packet* cpkt);
 
@@ -165,12 +165,12 @@ class SnoopFilter : public SimObject {
      * will update the corresponding state in the filter.
      *
      * @param cpkt     Pointer to const Packet holding the snoop response.
-     * @param rsp_port SlavePort that sends the response.
-     * @param req_port SlavePort that made the original request and is the
+     * @param rsp_port ResponsePort that sends the response.
+     * @param req_port ResponsePort that made the original request and is the
      *                 destination of the snoop response.
      */
-    void updateSnoopResponse(const Packet *cpkt, const SlavePort& rsp_port,
-                             const SlavePort& req_port);
+    void updateSnoopResponse(const Packet *cpkt, const ResponsePort& rsp_port,
+                             const ResponsePort& req_port);
 
     /**
      * Pass snoop responses that travel downward through the snoop
@@ -178,11 +178,11 @@ class SnoopFilter : public SimObject {
      * additional routing happens.
      *
      * @param cpkt     Pointer to const Packet holding the snoop response.
-     * @param rsp_port SlavePort that sends the response.
-     * @param req_port MasterPort through which the response is forwarded.
+     * @param rsp_port ResponsePort that sends the response.
+     * @param req_port RequestPort through which the response is forwarded.
      */
-    void updateSnoopForward(const Packet *cpkt, const SlavePort& rsp_port,
-                            const MasterPort& req_port);
+    void updateSnoopForward(const Packet *cpkt, const ResponsePort& rsp_port,
+                            const RequestPort& req_port);
 
     /**
      * Update the snoop filter with a response from below (outer /
@@ -190,10 +190,10 @@ class SnoopFilter : public SimObject {
      * the snoop filter.
      *
      * @param cpkt       Pointer to const Packet holding the snoop response.
-     * @param slave_port SlavePort that made the original request and
+     * @param slave_port ResponsePort that made the original request and
      *                   is the target of this response.
      */
-    void updateResponse(const Packet *cpkt, const SlavePort& slave_port);
+    void updateResponse(const Packet *cpkt, const ResponsePort& slave_port);
 
     virtual void regStats();
 
@@ -206,7 +206,7 @@ class SnoopFilter : public SimObject {
     typedef std::bitset<SNOOP_MASK_SIZE> SnoopMask;
 
     /**
-    * Per cache line item tracking a bitmask of SlavePorts who have an
+    * Per cache line item tracking a bitmask of ResponsePorts who have an
     * outstanding request to this line (requested) or already share a
     * cache line with this address (holder).
     */
@@ -239,14 +239,14 @@ class SnoopFilter : public SimObject {
 
     /**
      * Convert a single port to a corresponding, one-hot bitmask
-     * @param port SlavePort that should be converted.
+     * @param port ResponsePort that should be converted.
      * @return One-hot bitmask corresponding to the port.
      */
-    SnoopMask portToMask(const SlavePort& port) const;
+    SnoopMask portToMask(const ResponsePort& port) const;
     /**
      * Converts a bitmask of ports into the corresponing list of ports
      * @param ports SnoopMask of the requested ports
-     * @return SnoopList containing all the requested SlavePorts
+     * @return SnoopList containing all the requested ResponsePorts
      */
     SnoopList maskToPortList(SnoopMask ports) const;
 
@@ -320,7 +320,7 @@ class SnoopFilter : public SimObject {
 };
 
 inline SnoopFilter::SnoopMask
-SnoopFilter::portToMask(const SlavePort& port) const
+SnoopFilter::portToMask(const ResponsePort& port) const
 {
     assert(port.getId() != InvalidPortID);
     // if this is not a snooping port, return a zero mask

--- a/src/mem/token_port.cc
+++ b/src/mem/token_port.cc
@@ -109,7 +109,7 @@ TokenSlavePort::bind(Port& peer)
 void
 TokenSlavePort::unbind()
 {
-    SlavePort::slaveUnbind();
+    SlavePort::responderUnbind();
     tokenMasterPort = nullptr;
 }
 

--- a/src/mem/token_port.cc
+++ b/src/mem/token_port.cc
@@ -109,7 +109,7 @@ TokenSlavePort::bind(Port& peer)
 void
 TokenSlavePort::unbind()
 {
-    ResponsePort::slaveUnbind();
+    ResponsePort::responderUnbind();
     tokenMasterPort = nullptr;
 }
 

--- a/src/mem/token_port.cc
+++ b/src/mem/token_port.cc
@@ -42,7 +42,7 @@
 void
 TokenMasterPort::bind(Port &peer)
 {
-    MasterPort::bind(peer);
+    RequestPort::bind(peer);
 }
 
 void
@@ -88,10 +88,10 @@ void
 TokenSlavePort::bind(Port& peer)
 {
     // TokenSlavePort is allowed to bind to either TokenMasterPort or a
-    // MasterPort as fallback. If the type is a MasterPort, tokenMasterPort
+    // RequestPort as fallback. If the type is a RequestPort, tokenMasterPort
     // is set to nullptr to indicate tokens should not be exchanged.
     auto *token_master_port = dynamic_cast<TokenMasterPort*>(&peer);
-    auto *master_port = dynamic_cast<MasterPort*>(&peer);
+    auto *master_port = dynamic_cast<RequestPort*>(&peer);
     if (!token_master_port && !master_port) {
         fatal("Attempt to bind port %s to unsupported slave port %s.",
               name(), peer.name());
@@ -109,7 +109,7 @@ TokenSlavePort::bind(Port& peer)
 void
 TokenSlavePort::unbind()
 {
-    SlavePort::slaveUnbind();
+    ResponsePort::slaveUnbind();
     tokenMasterPort = nullptr;
 }
 
@@ -121,7 +121,7 @@ TokenSlavePort::recvRespRetry()
              "Attempted to retry a response when no retry was queued!\n");
 
     PacketPtr pkt = respQueue.front();
-    bool success = SlavePort::sendTimingResp(pkt);
+    bool success = ResponsePort::sendTimingResp(pkt);
 
     if (success) {
         respQueue.pop_front();
@@ -131,7 +131,7 @@ TokenSlavePort::recvRespRetry()
 bool
 TokenSlavePort::sendTimingResp(PacketPtr pkt)
 {
-    bool success = SlavePort::sendTimingResp(pkt);
+    bool success = ResponsePort::sendTimingResp(pkt);
 
     if (!success) {
         respQueue.push_back(pkt);

--- a/src/mem/token_port.hh
+++ b/src/mem/token_port.hh
@@ -40,7 +40,7 @@
 class TokenManager;
 class TokenSlavePort;
 
-class TokenMasterPort : public MasterPort
+class TokenMasterPort : public RequestPort
 {
   private:
     /* Manager to track tokens between this token port pair. */
@@ -49,7 +49,7 @@ class TokenMasterPort : public MasterPort
   public:
     TokenMasterPort(const std::string& name, SimObject* owner,
                     PortID id = InvalidPortID) :
-        MasterPort(name, owner, id), tokenManager(nullptr)
+        RequestPort(name, owner, id), tokenManager(nullptr)
     { }
 
     /**
@@ -87,7 +87,7 @@ class TokenMasterPort : public MasterPort
     void setTokenManager(TokenManager *_tokenManager);
 };
 
-class TokenSlavePort : public SlavePort
+class TokenSlavePort : public ResponsePort
 {
   private:
     TokenMasterPort *tokenMasterPort;
@@ -99,7 +99,7 @@ class TokenSlavePort : public SlavePort
   public:
     TokenSlavePort(const std::string& name, ClockedObject *owner,
                    PortID id = InvalidPortID) :
-        SlavePort(name, owner, id), tokenMasterPort(nullptr)
+        ResponsePort(name, owner, id), tokenMasterPort(nullptr)
     { }
     ~TokenSlavePort() { }
 

--- a/tests/gem5/cpu_tests/ref/FloatMM
+++ b/tests/gem5/cpu_tests/ref/FloatMM
@@ -1,0 +1,6 @@
+gem5 Simulator System.  http://gem5.org
+gem5 is copyrighted software; use the --copyright option for details.
+
+
+Global frequency set at 1000000000000 ticks per second
+-776.000061


### PR DESCRIPTION
Changing master slave terminology.

https://gem5.atlassian.net/browse/GEM5-9

Change-Id: I5e6e90b2916df4dbfccdaabe97423f377a1f6e3f