### PR TITLE
Documenting Port API's

### DIFF
--- a/src/mem/external_master.hh
+++ b/src/mem/external_master.hh
@@ -71,7 +71,7 @@ class ExternalMaster : public SimObject
 
       public:
         /**
-         * @ingroup api_port
+         * @ingroup api_external
          * @{
          */
         ExternalPort(const std::string &name_,
@@ -80,7 +80,7 @@ class ExternalMaster : public SimObject
         { }
 
         ~ExternalPort() { }
-        /** @} */ // end of api_port
+        /** @} */ // end of api_external
 
         /** Any or all of recv... can be overloaded to provide the port's
          *  functionality */
@@ -97,7 +97,7 @@ class ExternalMaster : public SimObject
          * Create or find an external port which can be bound. Returns
          * NULL on failure
          *
-         * @ingroup api_port
+         * @ingroup api_external
          */
         virtual ExternalPort *getExternalPort(
             const std::string &name, ExternalMaster &owner,
@@ -125,14 +125,14 @@ class ExternalMaster : public SimObject
 
   public:
     /**
-      * @ingroup api_port
+      * @ingroup api_external
       */
     ExternalMaster(ExternalMasterParams *params);
 
     /**
      * Port interface.  Responds only to port "port"
      *
-     * @ingroup api_port
+     * @ingroup api_external
      */
     Port &getPort(const std::string &if_name,
                   PortID idx=InvalidPortID) override;
@@ -141,7 +141,7 @@ class ExternalMaster : public SimObject
      * Register a handler which can provide ports with port_type ==
      * handler_name
      *
-     * @ingroup api_port
+     * @ingroup api_external
      */
     static void registerHandler(const std::string &handler_name,
         Handler *handler);

--- a/src/mem/external_master.hh
+++ b/src/mem/external_master.hh
@@ -70,12 +70,17 @@ class ExternalMaster : public SimObject
         ExternalMaster &owner;
 
       public:
+        /**
+         * @ingroup api_port
+         * @{
+         */
         ExternalPort(const std::string &name_,
             ExternalMaster &owner_) :
             MasterPort(name_, &owner_), owner(owner_)
         { }
 
         ~ExternalPort() { }
+        /** @} */ // end of api_port
 
         /** Any or all of recv... can be overloaded to provide the port's
          *  functionality */
@@ -88,8 +93,12 @@ class ExternalMaster : public SimObject
     class Handler
     {
       public:
-        /** Create or find an external port which can be bound.  Returns
-         *  NULL on failure */
+        /**
+         * Create or find an external port which can be bound. Returns
+         * NULL on failure
+         *
+         * @ingroup api_port
+         */
         virtual ExternalPort *getExternalPort(
             const std::string &name, ExternalMaster &owner,
             const std::string &port_data) = 0;
@@ -115,19 +124,36 @@ class ExternalMaster : public SimObject
     static std::map<std::string, Handler *> portHandlers;
 
   public:
+    /**
+      * @ingroup api_port
+      */
     ExternalMaster(ExternalMasterParams *params);
 
-    /** Port interface.  Responds only to port "port" */
+    /**
+     * Port interface.  Responds only to port "port"
+     *
+     * @ingroup api_port
+     */
     Port &getPort(const std::string &if_name,
                   PortID idx=InvalidPortID) override;
 
-    /** Register a handler which can provide ports with port_type ==
-     *  handler_name */
+    /**
+     * Register a handler which can provide ports with port_type ==
+     * handler_name
+     *
+     * @ingroup api_port
+     */
     static void registerHandler(const std::string &handler_name,
         Handler *handler);
 
+    /**
+      * @ingroup api_port
+      */
     void init() override;
 
+    /**
+      * @ingroup api_port
+      */
     const MasterID masterId;
 };
 

--- a/src/mem/external_master.hh
+++ b/src/mem/external_master.hh
@@ -146,14 +146,8 @@ class ExternalMaster : public SimObject
     static void registerHandler(const std::string &handler_name,
         Handler *handler);
 
-    /**
-      * @ingroup api_port
-      */
     void init() override;
 
-    /**
-      * @ingroup api_port
-      */
     const MasterID masterId;
 };
 

--- a/src/mem/external_master.hh
+++ b/src/mem/external_master.hh
@@ -124,16 +124,8 @@ class ExternalMaster : public SimObject
     static std::map<std::string, Handler *> portHandlers;
 
   public:
-    /**
-      * @ingroup api_external
-      */
     ExternalMaster(ExternalMasterParams *params);
 
-    /**
-     * Port interface.  Responds only to port "port"
-     *
-     * @ingroup api_external
-     */
     Port &getPort(const std::string &if_name,
                   PortID idx=InvalidPortID) override;
 

--- a/src/mem/external_slave.hh
+++ b/src/mem/external_slave.hh
@@ -73,7 +73,7 @@ class ExternalSlave : public SimObject
 
       public:
         /**
-         * @ingroup api_port
+         * @ingroup api_external
          * @{
          */
         ExternalPort(const std::string &name_,
@@ -82,7 +82,7 @@ class ExternalSlave : public SimObject
         { }
 
         ~ExternalPort() { }
-        /** @} */
+        /** @} */ // end of api_external
 
         /** Any or all of recv... can be overloaded to provide the port's
          *  functionality */
@@ -101,7 +101,7 @@ class ExternalSlave : public SimObject
          * Create or find an external port which can be bound. Returns
          * NULL on failure
          *
-         * @ingroup api_port
+         * @ingroup api_external
          */
         virtual ExternalPort *getExternalPort(
             const std::string &name, ExternalSlave &owner,
@@ -132,16 +132,8 @@ class ExternalSlave : public SimObject
     static std::map<std::string, Handler *> portHandlers;
 
   public:
-    /**
-     * @ingroup api_port
-     */
     ExternalSlave(ExternalSlaveParams *params);
 
-    /**
-     * Port interface. Responds only to port "port".
-     *
-     * @ingroup api_port
-     */
     Port &getPort(const std::string &if_name,
                   PortID idx=InvalidPortID) override;
 
@@ -149,14 +141,11 @@ class ExternalSlave : public SimObject
      * Register a handler which can provide ports with port_type ==
      * handler_name
      *
-     * @ingroup api_port
+     * @ingroup api_external
      */
     static void registerHandler(const std::string &handler_name,
         Handler *handler);
 
-    /**
-     * @ingroup api_port
-     */
     void init() override;
 };
 

--- a/src/mem/external_slave.hh
+++ b/src/mem/external_slave.hh
@@ -72,12 +72,17 @@ class ExternalSlave : public SimObject
         ExternalSlave &owner;
 
       public:
+        /**
+         * @ingroup api_port
+         * @{
+         */
         ExternalPort(const std::string &name_,
             ExternalSlave &owner_) :
             SlavePort(name_, &owner_), owner(owner_)
         { }
 
         ~ExternalPort() { }
+        /** @} */
 
         /** Any or all of recv... can be overloaded to provide the port's
          *  functionality */
@@ -92,8 +97,12 @@ class ExternalSlave : public SimObject
     class Handler
     {
       public:
-        /** Create or find an external port which can be bound.  Returns
-         *  NULL on failure */
+        /** 
+         * Create or find an external port which can be bound. Returns
+         * NULL on failure
+         *
+         * @ingroup api_port
+         */
         virtual ExternalPort *getExternalPort(
             const std::string &name, ExternalSlave &owner,
             const std::string &port_data) = 0;
@@ -123,17 +132,31 @@ class ExternalSlave : public SimObject
     static std::map<std::string, Handler *> portHandlers;
 
   public:
+    /**
+     * @ingroup api_port
+     */
     ExternalSlave(ExternalSlaveParams *params);
 
-    /** Port interface.  Responds only to port "port" */
+    /**
+     * Port interface. Responds only to port "port".
+     *
+     * @ingroup api_port
+     */
     Port &getPort(const std::string &if_name,
                   PortID idx=InvalidPortID) override;
 
-    /** Register a handler which can provide ports with port_type ==
-     *  handler_name */
+    /**
+     * Register a handler which can provide ports with port_type ==
+     * handler_name
+     *
+     * @ingroup api_port
+     */
     static void registerHandler(const std::string &handler_name,
         Handler *handler);
 
+    /**
+     * @ingroup api_port
+     */
     void init() override;
 };
 

--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -92,15 +92,11 @@ class MasterPort : public Port, public AtomicRequestProtocol,
     /**
      * Bind this master port to a slave port. This also does the
      * mirror action and binds the slave port to the master port.
-     *
-     * @ingroup api_port
      */
     void bind(Port &peer) override;
 
     /**
      * Unbind this master port and the associated slave port.
-     *
-     * @ingroup api_port
      */
     void unbind() override;
 
@@ -328,15 +324,9 @@ class SlavePort : public Port, public AtomicResponseProtocol,
      */
     virtual AddrRangeList getAddrRanges() const = 0;
 
-    /**
-     * We let the master port do the work, so these don't do anything.
-     *
-     * @ingroup api_port
-     * @{
-     */
     void unbind() override {}
     void bind(Port &peer) override {}
-    /** @} */ // end of api_port
+
   public:
     /* The atomic protocol. */
 

--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -292,19 +292,28 @@ class SlavePort : public Port, public AtomicResponseProtocol,
     SimObject& owner;
 
   public:
+    /**
+     * @ingroup api_port
+     * @{
+     */
     SlavePort(const std::string& name, SimObject* _owner,
               PortID id=InvalidPortID);
     virtual ~SlavePort();
+    /** @} */ // end of api_port
 
     /**
      * Find out if the peer master port is snooping or not.
      *
      * @return true if the peer master port is snooping
+     *
+     * @ingroup api_port
      */
     bool isSnooping() const { return _masterPort->isSnooping(); }
 
     /**
-     * Called by the owner to send a range change
+     * Called by the owner to send a range change.
+     *
+     * @ingroup api_port
      */
     void sendRangeChange() const { _masterPort->recvRangeChange(); }
 
@@ -314,15 +323,20 @@ class SlavePort : public Port, public AtomicResponseProtocol,
      * and return a populated list with at least one item.
      *
      * @return a list of ranges responded to
+     *
+     * @ingroup api_port
      */
     virtual AddrRangeList getAddrRanges() const = 0;
 
     /**
      * We let the master port do the work, so these don't do anything.
+     *
+     * @ingroup api_port
+     * @{
      */
     void unbind() override {}
     void bind(Port &peer) override {}
-
+    /** @} */ // end of api_port
   public:
     /* The atomic protocol. */
 
@@ -354,6 +368,8 @@ class SlavePort : public Port, public AtomicResponseProtocol,
      * affecting the current state of any block or moving the block.
      *
      * @param pkt Snoop packet to send.
+     *
+     * @ingroup api_port
      */
     void
     sendFunctionalSnoop(PacketPtr pkt) const
@@ -378,6 +394,8 @@ class SlavePort : public Port, public AtomicResponseProtocol,
      * @param pkt Packet to send.
      *
      * @return If the send was succesful or not.
+     *
+     * @ingroup api_port
     */
     bool
     sendTimingResp(PacketPtr pkt)
@@ -395,6 +413,8 @@ class SlavePort : public Port, public AtomicResponseProtocol,
      * always succeed and hence no return value is needed.
      *
      * @param pkt Packet to send.
+     *
+     * @ingroup api_port
      */
     void
     sendTimingSnoopReq(PacketPtr pkt)
@@ -409,6 +429,8 @@ class SlavePort : public Port, public AtomicResponseProtocol,
     /**
      * Send a retry to the master port that previously attempted a
      * sendTimingReq to this slave port and failed.
+     *
+     * @ingroup api_port
      */
     void
     sendRetryReq()
@@ -423,6 +445,8 @@ class SlavePort : public Port, public AtomicResponseProtocol,
     /**
      * Send a retry to the master port that previously attempted a
      * sendTimingSnoopResp to this slave port and failed.
+     *
+     * @ingroup api_port
      */
     void
     sendRetrySnoopResp()

--- a/src/mem/port.hh
+++ b/src/mem/port.hh
@@ -80,18 +80,27 @@ class MasterPort : public Port, public AtomicRequestProtocol,
     SimObject &owner;
 
   public:
+    /**
+     * @ingroup api_port
+     * @{
+     */
     MasterPort(const std::string& name, SimObject* _owner,
                PortID id=InvalidPortID);
     virtual ~MasterPort();
+    /** @}*/ //end of api_port
 
     /**
      * Bind this master port to a slave port. This also does the
      * mirror action and binds the slave port to the master port.
+     *
+     * @ingroup api_port
      */
     void bind(Port &peer) override;
 
     /**
      * Unbind this master port and the associated slave port.
+     *
+     * @ingroup api_port
      */
     void unbind() override;
 
@@ -103,11 +112,15 @@ class MasterPort : public Port, public AtomicRequestProtocol,
      * function.
      *
      * @return true if the port should be considered a snooper
+     *
+     * @ingroup api_port
      */
     virtual bool isSnooping() const { return false; }
 
     /**
      * Get the address ranges of the connected slave port.
+     *
+     * @ingroup api_port
      */
     AddrRangeList getAddrRanges() const;
 
@@ -128,6 +141,8 @@ class MasterPort : public Port, public AtomicRequestProtocol,
      * @param pkt Packet to send.
      *
      * @return Estimated latency of access.
+     *
+     * @ingroup api_port
      */
     Tick sendAtomic(PacketPtr pkt);
 
@@ -140,6 +155,8 @@ class MasterPort : public Port, public AtomicRequestProtocol,
      *        caller have direct access to the requested data.
      *
      * @return Estimated latency of access.
+     *
+     * @ingroup api_port
      */
     Tick sendAtomicBackdoor(PacketPtr pkt, MemBackdoorPtr &backdoor);
 
@@ -152,6 +169,8 @@ class MasterPort : public Port, public AtomicRequestProtocol,
      * current state of any block or moving the block.
      *
      * @param pkt Packet to send.
+     *
+     * @ingroup api_port
      */
     void sendFunctional(PacketPtr pkt) const;
 
@@ -168,6 +187,8 @@ class MasterPort : public Port, public AtomicRequestProtocol,
      * @param pkt Packet to send.
      *
      * @return If the send was succesful or not.
+     *
+     * @ingroup api_port
     */
     bool sendTimingReq(PacketPtr pkt);
 
@@ -181,6 +202,8 @@ class MasterPort : public Port, public AtomicRequestProtocol,
      * @param pkt Packet to send.
      *
      * @return If the send was succesful or not.
+     *
+     * @ingroup api_port
      */
     bool tryTiming(PacketPtr pkt) const;
 
@@ -192,6 +215,8 @@ class MasterPort : public Port, public AtomicRequestProtocol,
      * re-issue a sendTimingSnoopResp.
      *
      * @param pkt Packet to send.
+     *
+     * @ingroup api_port
      */
     bool sendTimingSnoopResp(PacketPtr pkt);
 
@@ -200,6 +225,8 @@ class MasterPort : public Port, public AtomicRequestProtocol,
      * sendTimingResp to this master port and failed. Note that this
      * is virtual so that the "fake" snoop response port in the
      * coherent crossbar can override the behaviour.
+     *
+     * @ingroup api_port
      */
     virtual void sendRetryResp();
 

--- a/src/mem/port_proxy.hh
+++ b/src/mem/port_proxy.hh
@@ -97,6 +97,10 @@ class PortProxy : FunctionalRequestProtocol
     }
 
   public:
+    /**
+     * @ingroup api_port
+     * @{
+     */
     PortProxy(SendFunctionalFunc func, unsigned int cacheLineSize) :
         sendFunctional(func), _cacheLineSize(cacheLineSize)
     {}
@@ -106,25 +110,31 @@ class PortProxy : FunctionalRequestProtocol
             }), _cacheLineSize(cacheLineSize)
     {}
     virtual ~PortProxy() { }
-
+    /** @} */ // end api_port
 
 
     /** Fixed functionality for use in base classes. */
 
     /**
      * Read size bytes memory at physical address and store in p.
+     *
+     * @ingroup api_port
      */
     void readBlobPhys(Addr addr, Request::Flags flags,
                       void *p, int size) const;
 
     /**
      * Write size bytes from p to physical address.
+     *
+     * @ingroup api_port
      */
     void writeBlobPhys(Addr addr, Request::Flags flags,
                        const void *p, int size) const;
 
     /**
      * Fill size bytes starting at physical addr with byte value val.
+     *
+     * @ingroup api_port
      */
     void memsetBlobPhys(Addr addr, Request::Flags flags,
                         uint8_t v, int size) const;
@@ -136,6 +146,8 @@ class PortProxy : FunctionalRequestProtocol
     /**
      * Read size bytes memory at address and store in p.
      * Returns true on success and false on failure.
+     *
+     * @ingroup api_port
      */
     virtual bool
     tryReadBlob(Addr addr, void *p, int size) const
@@ -147,6 +159,8 @@ class PortProxy : FunctionalRequestProtocol
     /**
      * Write size bytes from p to address.
      * Returns true on success and false on failure.
+     *
+     * @ingroup api_port
      */
     virtual bool
     tryWriteBlob(Addr addr, const void *p, int size) const
@@ -158,6 +172,8 @@ class PortProxy : FunctionalRequestProtocol
     /**
      * Fill size bytes starting at addr with byte value val.
      * Returns true on success and false on failure.
+     *
+     * @ingroup api_port
      */
     virtual bool
     tryMemsetBlob(Addr addr, uint8_t val, int size) const
@@ -172,6 +188,8 @@ class PortProxy : FunctionalRequestProtocol
 
     /**
      * Same as tryReadBlob, but insists on success.
+     *
+     * @ingroup api_port
      */
     void
     readBlob(Addr addr, void *p, int size) const
@@ -182,6 +200,8 @@ class PortProxy : FunctionalRequestProtocol
 
     /**
      * Same as tryWriteBlob, but insists on success.
+     *
+     * @ingroup api_port
      */
     void
     writeBlob(Addr addr, const void *p, int size) const
@@ -192,6 +212,8 @@ class PortProxy : FunctionalRequestProtocol
 
     /**
      * Same as tryMemsetBlob, but insists on success.
+     *
+     * @ingroup api_port
      */
     void
     memsetBlob(Addr addr, uint8_t v, int size) const
@@ -202,12 +224,16 @@ class PortProxy : FunctionalRequestProtocol
 
     /**
      * Read sizeof(T) bytes from address and return as object T.
+     *
+     * @ingroup api_port
      */
     template <typename T>
     T read(Addr address) const;
 
     /**
      * Write object T to address. Writes sizeof(T) bytes.
+     *
+     * @ingroup api_port
      */
     template <typename T>
     void write(Addr address, const T &data) const;
@@ -215,6 +241,8 @@ class PortProxy : FunctionalRequestProtocol
     /**
      * Read sizeof(T) bytes from address and return as object T.
      * Performs endianness conversion from the selected guest to host order.
+     *
+     * @ingroup api_port
      */
     template <typename T>
     T read(Addr address, ByteOrder guest_byte_order) const;
@@ -222,6 +250,8 @@ class PortProxy : FunctionalRequestProtocol
     /**
      * Write object T to address. Writes sizeof(T) bytes.
      * Performs endianness conversion from host to the selected guest order.
+     *
+     * @ingroup api_port
      */
     template <typename T>
     void write(Addr address, T data, ByteOrder guest_byte_order) const;
@@ -229,11 +259,15 @@ class PortProxy : FunctionalRequestProtocol
     /**
      * Write the string str into guest memory at address addr.
      * Returns true on success and false on failure.
+     *
+     * @ingroup api_port
      */
     bool tryWriteString(Addr addr, const char *str) const;
 
     /**
      * Same as tryWriteString, but insists on success.
+     *
+     * @ingroup api_port
      */
     void
     writeString(Addr addr, const char *str) const
@@ -245,11 +279,15 @@ class PortProxy : FunctionalRequestProtocol
     /**
      * Reads the string at guest address addr into the std::string str.
      * Returns true on success and false on failure.
+     *
+     * @ingroup api_port
      */
     bool tryReadString(std::string &str, Addr addr) const;
 
     /**
      * Same as tryReadString, but insists on success.
+     *
+     * @ingroup api_port
      */
     void
     readString(std::string &str, Addr addr) const
@@ -262,11 +300,15 @@ class PortProxy : FunctionalRequestProtocol
      * Reads the string at guest address addr into the char * str, reading up
      * to maxlen characters. The last character read is always a nul
      * terminator. Returns true on success and false on failure.
+     *
+     * @ingroup api_port
      */
     bool tryReadString(char *str, Addr addr, size_t maxlen) const;
 
     /**
      * Same as tryReadString, but insists on success.
+     *
+     * @ingroup api_port
      */
     void
     readString(char *str, Addr addr, size_t maxlen) const

--- a/src/mem/ruby/system/RubyPortProxy.hh
+++ b/src/mem/ruby/system/RubyPortProxy.hh
@@ -58,23 +58,17 @@ class RubyPortProxy : public RubyPort
      * Create a new RubyPortProxy.
      *
      * @param p Parameters inherited from the RubyPort
-     *
-     * @ingroup api_port
      */
     RubyPortProxy(const RubyPortProxyParams* p);
 
     /**
      * Destruct a RubyPortProxy.
-     *
-     * @ingroup api_port
      */
     virtual ~RubyPortProxy();
 
     /**
      * Initialise a RubyPortProxy by doing nothing and avoid
      * involving the super class.
-     *
-     * @ingroup api_port
      */
     void init();
 
@@ -85,8 +79,6 @@ class RubyPortProxy : public RubyPort
      *
      * @param pkt The packet to serve to Ruby
      * @returns always a NULL status
-     *
-     * @ingroup api_port
      */
     RequestStatus makeRequest(PacketPtr pkt);
 
@@ -96,8 +88,6 @@ class RubyPortProxy : public RubyPort
      * functional accesses).
      *
      * @returns always 0
-     *
-     * @ingroup api_port
      */
     int outstandingCount() const { return 0; }
 
@@ -107,8 +97,6 @@ class RubyPortProxy : public RubyPort
      * functional accesses).
      *
      * @returns always false
-     *
-     * @ingroup api_port
      */
     bool isDeadlockEventScheduled() const { return false; }
 
@@ -116,8 +104,6 @@ class RubyPortProxy : public RubyPort
      * Pure virtual member in the super class that we are forced to
      * implement even if it is never used (since there are only
      * functional accesses).
-     *
-     * @ingroup api_port
      */
     void descheduleDeadlockEvent() { }
 

--- a/src/mem/ruby/system/RubyPortProxy.hh
+++ b/src/mem/ruby/system/RubyPortProxy.hh
@@ -58,17 +58,23 @@ class RubyPortProxy : public RubyPort
      * Create a new RubyPortProxy.
      *
      * @param p Parameters inherited from the RubyPort
+     *
+     * @ingroup api_port
      */
     RubyPortProxy(const RubyPortProxyParams* p);
 
     /**
      * Destruct a RubyPortProxy.
+     *
+     * @ingroup api_port
      */
     virtual ~RubyPortProxy();
 
     /**
      * Initialise a RubyPortProxy by doing nothing and avoid
      * involving the super class.
+     *
+     * @ingroup api_port
      */
     void init();
 
@@ -79,6 +85,8 @@ class RubyPortProxy : public RubyPort
      *
      * @param pkt The packet to serve to Ruby
      * @returns always a NULL status
+     *
+     * @ingroup api_port
      */
     RequestStatus makeRequest(PacketPtr pkt);
 
@@ -88,6 +96,8 @@ class RubyPortProxy : public RubyPort
      * functional accesses).
      *
      * @returns always 0
+     *
+     * @ingroup api_port
      */
     int outstandingCount() const { return 0; }
 
@@ -97,6 +107,8 @@ class RubyPortProxy : public RubyPort
      * functional accesses).
      *
      * @returns always false
+     *
+     * @ingroup api_port
      */
     bool isDeadlockEventScheduled() const { return false; }
 
@@ -104,6 +116,8 @@ class RubyPortProxy : public RubyPort
      * Pure virtual member in the super class that we are forced to
      * implement even if it is never used (since there are only
      * functional accesses).
+     *
+     * @ingroup api_port
      */
     void descheduleDeadlockEvent() { }
 

--- a/src/mem/se_translating_port_proxy.hh
+++ b/src/mem/se_translating_port_proxy.hh
@@ -59,6 +59,9 @@ class SETranslatingPortProxy : public TranslatingPortProxy
   protected:
     bool fixupAddr(Addr addr, BaseTLB::Mode mode) const override;
 
+  /**
+   * @ingroup api_port
+   */
   public:
     SETranslatingPortProxy(ThreadContext *tc, AllocType alloc=NextPage,
                            Request::Flags _flags=0);

--- a/src/mem/translating_port_proxy.hh
+++ b/src/mem/translating_port_proxy.hh
@@ -80,23 +80,17 @@ class TranslatingPortProxy : public PortProxy
     /**
      * Version of tryReadblob that translates virt->phys and deals
      * with page boundries.
-     *
-     * @ingroup api_port
      */
     bool tryReadBlob(Addr addr, void *p, int size) const override;
 
     /**
      * Version of tryWriteBlob that translates virt->phys and deals
      * with page boundries.
-     *
-     * @ingroup api_port
      */
     bool tryWriteBlob(Addr addr, const void *p, int size) const override;
 
     /**
      * Fill size bytes starting at addr with byte value val.
-     *
-     * @ingroup api_port
      */
     bool tryMemsetBlob(Addr address, uint8_t  v, int size) const override;
 };

--- a/src/mem/translating_port_proxy.hh
+++ b/src/mem/translating_port_proxy.hh
@@ -72,18 +72,31 @@ class TranslatingPortProxy : public PortProxy
 
   public:
 
+    /**
+     * @ingroup api_port
+     */
     TranslatingPortProxy(ThreadContext *tc, Request::Flags _flags=0);
 
-    /** Version of tryReadblob that translates virt->phys and deals
-      * with page boundries. */
+    /**
+     * Version of tryReadblob that translates virt->phys and deals
+     * with page boundries.
+     *
+     * @ingroup api_port
+     */
     bool tryReadBlob(Addr addr, void *p, int size) const override;
 
-    /** Version of tryWriteBlob that translates virt->phys and deals
-      * with page boundries. */
+    /**
+     * Version of tryWriteBlob that translates virt->phys and deals
+     * with page boundries.
+     *
+     * @ingroup api_port
+     */
     bool tryWriteBlob(Addr addr, const void *p, int size) const override;
 
     /**
      * Fill size bytes starting at addr with byte value val.
+     *
+     * @ingroup api_port
      */
     bool tryMemsetBlob(Addr address, uint8_t  v, int size) const override;
 };

--- a/src/sim/port.hh
+++ b/src/sim/port.hh
@@ -96,19 +96,37 @@ class Port
 
     /**
      * Virtual destructor due to inheritance.
+     *
+     * @ingroup api_port
      */
     virtual ~Port();
 
-    /** Return a reference to this port's peer. */
+    /**
+     * Return a reference to this port's peer. 
+     *
+     * @ingroup api_port
+     */
     Port &getPeer() { return *_peer; }
 
-    /** Return port name (for DPRINTF). */
+    /**
+     * Return port name (for DPRINTF).
+     *
+     * @ingroup api_port
+     */
     const std::string name() const { return portName; }
 
-    /** Get the port id. */
+    /**
+     * Get the port id. 
+     *
+     * @ingroup api_port
+     */
     PortID getId() const { return id; }
 
-    /** Attach to a peer port. */
+    /**
+     * Attach to a peer port. 
+     *
+     * @ingroup api_port
+     */
     virtual void
     bind(Port &peer)
     {
@@ -116,7 +134,11 @@ class Port
         _connected = true;
     }
 
-    /** Dettach from a peer port. */
+    /**
+     * Dettach from a peer port.
+     *
+     * @ingroup api_port
+     */
     virtual void
     unbind()
     {
@@ -124,10 +146,18 @@ class Port
         _connected = false;
     }
 
-    /** Is this port currently connected to a peer? */
+    /**
+     * Is this port currently connected to a peer?
+     *
+     * @ingroup api_port
+     */
     bool isConnected() const { return _connected; }
 
-    /** A utility function to make it easier to swap out ports. */
+    /** 
+     * A utility function to make it easier to swap out ports.
+     *
+     * @ingroup api_port
+     */
     void
     takeOverFrom(Port *old)
     {
@@ -147,6 +177,9 @@ class Port
     }
 };
 
+/**
+ * @ingroup api_port
+ */
 static inline std::ostream &
 operator << (std::ostream &os, const Port &port)
 {


### PR DESCRIPTION
This is not finished yet.

Documented:
- Port / PortProxy / TranslatingPortProxy
- MasterPort / SlavePort
- ExternalMaster / ExternalSlave
- <s>RubyPortProxy</s>

A few notes:
- I don't know users need access to Ruby beyond the RubyPortProxy. I don't know whether RubyPort itself should be a part of the API's. If this is the case then should we also documenting PortProxy etc.