### PR TITLE
Deprecating Param Error

### DIFF
--- a/src/arch/x86/X86LocalApic.py
+++ b/src/arch/x86/X86LocalApic.py
@@ -48,8 +48,15 @@ class X86LocalApic(BaseInterrupts):
     type = 'X86LocalApic'
     cxx_class = 'X86ISA::Interrupts'
     cxx_header = 'arch/x86/interrupts.hh'
-    int_master = RequestPort("Port for sending interrupt messages")
-    int_slave = ResponsePort("Port for receiving interrupt messages")
+
+    int_requestor = RequestPort("Port for sending interrupt messages")
+    int_master    = DeprecatedParam(int_requestor,
+                        '`int_master` is now called `int_requestor`')
+
+    int_responder = ResponsePort("Port for receiving interrupt messages")
+    int_slave     = DeprecatedParam(int_responder,
+                        '`int_slave` is now called `int_responder`')
+
     int_latency = Param.Latency('1ns', \
             "Latency for an interrupt to propagate through this device.")
     pio = ResponsePort("Programmed I/O port")

--- a/src/arch/x86/interrupts.cc
+++ b/src/arch/x86/interrupts.cc
@@ -603,8 +603,8 @@ X86ISA::Interrupts::Interrupts(Params *p)
       pendingStartup(false), startupVector(0),
       startedUp(false), pendingUnmaskableInt(false),
       pendingIPIs(0),
-      intSlavePort(name() + ".int_slave", this, this),
-      intMasterPort(name() + ".int_master", this, this, p->int_latency),
+      intSlavePort(name() + ".int_responder", this, this),
+      intMasterPort(name() + ".int_requestor", this, this, p->int_latency),
       pioPort(this), pioDelay(p->pio_latency)
 {
     memset(regs, 0, sizeof(regs));

--- a/src/arch/x86/interrupts.hh
+++ b/src/arch/x86/interrupts.hh
@@ -228,9 +228,9 @@ class Interrupts : public BaseInterrupts
     Port &getPort(const std::string &if_name,
                   PortID idx=InvalidPortID) override
     {
-        if (if_name == "int_master") {
+        if (if_name == "int_requestor") {
             return intMasterPort;
-        } else if (if_name == "int_slave") {
+        } else if (if_name == "int_responder") {
             return intSlavePort;
         } else if (if_name == "pio") {
             return pioPort;

--- a/src/cpu/BaseCPU.py
+++ b/src/cpu/BaseCPU.py
@@ -188,8 +188,8 @@ class BaseCPU(ClockedObject):
     _uncached_master_ports = []
     if buildEnv['TARGET_ISA'] == 'x86':
         _uncached_slave_ports += ["interrupts[0].pio",
-                                  "interrupts[0].int_slave"]
-        _uncached_master_ports += ["interrupts[0].int_master"]
+                                  "interrupts[0].int_responder"]
+        _uncached_master_ports += ["interrupts[0].int_requestor"]
 
     def createInterruptController(self):
         self.interrupts = [ArchInterrupts() for i in range(self.numThreads)]

--- a/src/dev/x86/I82094AA.py
+++ b/src/dev/x86/I82094AA.py
@@ -34,7 +34,7 @@ class I82094AA(BasicPioDevice):
     cxx_class = 'X86ISA::I82094AA'
     cxx_header = "dev/x86/i82094aa.hh"
     apic_id = Param.Int(1, 'APIC id for this IO APIC')
-    int_master = RequestPort("Port for sending interrupt messages")
+    int_requestor = RequestPort("Port for sending interrupt messages")
     int_latency = Param.Latency('1ns', \
             "Latency for an interrupt to propagate through this device.")
     external_int_pic = Param.I8259(NULL, "External PIC, if any")

--- a/src/dev/x86/SouthBridge.py
+++ b/src/dev/x86/SouthBridge.py
@@ -108,4 +108,4 @@ class SouthBridge(SimObject):
         self.pit.pio = bus.master
         self.speaker.pio = bus.master
         self.io_apic.pio = bus.master
-        self.io_apic.int_master = bus.slave
+        self.io_apic.int_requestor = bus.slave

--- a/src/dev/x86/i82094aa.cc
+++ b/src/dev/x86/i82094aa.cc
@@ -42,7 +42,7 @@
 X86ISA::I82094AA::I82094AA(Params *p)
     : BasicPioDevice(p, 20), extIntPic(p->external_int_pic),
       lowestPriorityOffset(0),
-      intMasterPort(name() + ".int_master", this, this, p->int_latency)
+      intMasterPort(name() + ".int_requestor", this, this, p->int_latency)
 {
     // This assumes there's only one I/O APIC in the system and since the apic
     // id is stored in a 8-bit field with 0xff meaning broadcast, the id must
@@ -79,7 +79,7 @@ X86ISA::I82094AA::init()
 Port &
 X86ISA::I82094AA::getPort(const std::string &if_name, PortID idx)
 {
-    if (if_name == "int_master")
+    if (if_name == "int_requestor")
         return intMasterPort;
     if (if_name == "inputs")
         return *inputs.at(idx);

--- a/src/mem/Bridge.py
+++ b/src/mem/Bridge.py
@@ -42,8 +42,12 @@ from m5.objects.ClockedObject import ClockedObject
 class Bridge(ClockedObject):
     type = 'Bridge'
     cxx_header = "mem/bridge.hh"
-    slave = ResponsePort('Slave port')
-    master = RequestPort('Master port')
+
+    cpu_side = ResponsePort('This port receives requests and sends responses')
+    slave    = DeprecatedParam(cpu_side, '`slave` is now called `cpu_side`')
+    mem_side = RequestPort('This port sends requests and receives responses')
+    master   = DeprecatedParam(mem_side, '`master` is now called `mem_side`')
+
     req_size = Param.Unsigned(16, "The number of requests to buffer")
     resp_size = Param.Unsigned(16, "The number of responses to buffer")
     delay = Param.Latency('0ns', "The latency of this bridge")

--- a/src/mem/bridge.cc
+++ b/src/mem/bridge.cc
@@ -74,9 +74,9 @@ Bridge::BridgeMasterPort::BridgeMasterPort(const std::string& _name,
 
 Bridge::Bridge(Params *p)
     : ClockedObject(p),
-      slavePort(p->name + ".slave", *this, masterPort,
+      slavePort(p->name + ".cpu_side", *this, masterPort,
                 ticksToCycles(p->delay), p->resp_size, p->ranges),
-      masterPort(p->name + ".master", *this, slavePort,
+      masterPort(p->name + ".mem_side", *this, slavePort,
                  ticksToCycles(p->delay), p->req_size)
 {
 }
@@ -84,9 +84,9 @@ Bridge::Bridge(Params *p)
 Port &
 Bridge::getPort(const std::string &if_name, PortID idx)
 {
-    if (if_name == "master")
+    if (if_name == "mem_side")
         return masterPort;
-    else if (if_name == "slave")
+    else if (if_name == "cpu_side")
         return slavePort;
     else
         // pass it along to our super class

--- a/src/python/m5/SimObject.py
+++ b/src/python/m5/SimObject.py
@@ -467,6 +467,12 @@ class MetaSimObject(type):
         cls._params = multidict() # param descriptions
         cls._ports = multidict()  # port descriptions
 
+        # Parameter names that are deprecated. Dict[str, DeprecatedParam]
+        # The key is the "old_name" so that when the old_name is used in
+        # python config files, we will use the DeprecatedParam object to
+        # translate to the new type.
+        cls._deprecated_params = multidict()
+
         # class or instance attributes
         cls._values = multidict()   # param values
         cls._hr_values = multidict() # human readable param values
@@ -495,6 +501,7 @@ class MetaSimObject(type):
             cls._base = base
             cls._params.parent = base._params
             cls._ports.parent = base._ports
+            cls._deprecated_params = base._deprecated_params
             cls._values.parent = base._values
             cls._hr_values.parent = base._hr_values
             cls._children.parent = base._children
@@ -531,6 +538,15 @@ class MetaSimObject(type):
             # port objects
             elif isinstance(val, Port):
                 cls._new_port(key, val)
+
+            # Deprecated variable names
+            elif isinstance(val, DeprecatedParam):
+                new_name, new_val = cls._get_param_by_value(val.newParam)
+                # Note: We don't know the (string) name of this variable until
+                # here, so now we can finish setting up the dep_param.
+                val.oldName = key
+                val.newName = new_name
+                cls._deprecated_params[key] = val
 
             # init-time-only keywords
             elif key in cls.init_keywords:
@@ -603,6 +619,18 @@ class MetaSimObject(type):
             ref = cls._ports[attr].makeRef(cls)
             cls._port_refs[attr] = ref
         return ref
+
+    def _get_param_by_value(cls, value):
+        """Given an object, value, return the name and the value from the
+        internal list of parameter values. If this value can't be found, raise
+        a runtime error. This will search both the current object and its
+        parents.
+        """
+        for k,v in cls._value_dict.items():
+            if v == value:
+                return k,v
+        raise RuntimeError("Cannot find parameter {} in parameter list"
+                           .format(value))
 
     # Set attribute (called on foo.attr = value when foo is an
     # instance of class cls).
@@ -1255,6 +1283,11 @@ class SimObject(object):
         return ref
 
     def __getattr__(self, attr):
+        if attr in self._deprecated_params:
+            dep_param = self._deprecated_params[attr]
+            dep_param.printWarning(self._name, self.__class__.__name__)
+            return getattr(self, self._deprecated_params[attr].newName)
+
         if attr in self._ports:
             return self._get_port_ref(attr)
 
@@ -1286,6 +1319,11 @@ class SimObject(object):
         if attr.startswith('_'):
             object.__setattr__(self, attr, value)
             return
+
+        if attr in self._deprecated_params:
+            dep_param = self._deprecated_params[attr]
+            dep_param.printWarning(self._name, self.__class__.__name__)
+            return setattr(self, self._deprecated_params[attr].newName, value)
 
         if attr in self._ports:
             # set up port connection

--- a/src/python/m5/params.py
+++ b/src/python/m5/params.py
@@ -2162,6 +2162,71 @@ class PortParamDesc(object):
     ptype_str = 'Port'
     ptype = Port
 
+class DeprecatedParam(object):
+    """A special type for deprecated parameter variable names.
+
+    There are times when we need to change the name of parameter, but this
+    breaks the external-facing python API used in configuration files. Using
+    this "type" for a parameter will warn users that they are using the old
+    name, but allow for backwards compatibility.
+
+    Usage example:
+    In the following example, the `time` parameter is changed to `delay`.
+
+    ```
+    class SomeDevice(SimObject):
+        delay = Param.Latency('1ns', 'The time to wait before something')
+        time = DeprecatedParam(delay, '`time` is now called `delay`')
+    ```
+    """
+
+    def __init__(self, new_param, message=''):
+        """new_param: the new parameter variable that users should be using
+        instead of this parameter variable.
+        message: an optional message to print when warning the user
+        """
+        self.message = message
+        self.newParam = new_param
+        # Note: We won't know the string variable names until later in the
+        # SimObject initialization process. Note: we expect that the setters
+        # will be called when the SimObject type (class) is initialized so
+        # these variables should be filled in before the instance of the
+        # SimObject with this parameter is constructed
+        self._oldName = ''
+        self._newName = ''
+        self._message = ''
+
+    @property
+    def oldName(self):
+        assert(self._oldName != '') # should already be set
+        return self._oldName
+
+    @oldName.setter
+    def oldName(self, name):
+        assert(self._oldName == '') # Cannot "re-set" this value
+        self._oldName = name
+
+    @property
+    def newName(self):
+        assert(self._newName != '') # should already be set
+        return self._newName
+
+    @newName.setter
+    def newName(self, name):
+        assert(self._newName == '') # Cannot "re-set" this value
+        self._newName = name
+
+    def printWarning(self, instance_name, simobj_name):
+        """Issue a warning that this variable name should not be used.
+
+        instance_name: str, the name of the instance used in python
+        simobj_name: str, the name of the SimObject type
+        """
+        if not self.message:
+            self.message = "See {} for more information".format(simobj_name)
+        warn('{}.{} is deprecated. {}'.format(
+            instance_name, self._oldName, self.message))
+
 baseEnums = allEnums.copy()
 baseParams = allParams.copy()
 
@@ -2187,4 +2252,6 @@ __all__ = ['Param', 'VectorParam',
            'NextEthernetAddr', 'NULL',
            'Port', 'RequestPort', 'ResponsePort', 'MasterPort', 'SlavePort',
            'VectorPort', 'VectorRequestPort', 'VectorResponsePort',
-           'VectorMasterPort', 'VectorSlavePort']
+           'VectorMasterPort', 'VectorSlavePort',
+           'DeprecatedParam',
+           ]


### PR DESCRIPTION
This branch has the DeprecatedParam type patch, as well as a successful variable change of the interrupt ports. The ports in Bridge.py have been deprecated and changed, and gem5 builds however the tests fail and running simple.py or two_level.py causes this error:
```
 Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "build/X86/python/m5/main.py", line 457, in main
    exec(filecode, scope)
  File "configs/learning_gem5/part1/two_level.py", line 108, in <module>
    system.cpu.icache.connectBus(system.l2bus)
  File "configs/learning_gem5/part1/caches.py", line 65, in connectBus
    self.mem_side = bus.slave
  File "build/X86/python/m5/SimObject.py", line 1289, in __getattr__
    return getattr(self, self._deprecated_params[attr].newName)
  File "build/X86/python/m5/SimObject.py", line 1313, in __getattr__
    raise AttributeError(err_string)
AttributeError: object 'L2XBar' has no attribute 'cpu_side'
  (C++ object is not yet constructed, so wrapped C++ methods are unavailable.)
```