### PR TITLE
Hn/base api notes

### DIFF
--- a/src/base/addr_range.hh
+++ b/src/base/addr_range.hh
@@ -88,6 +88,9 @@ class AddrRange
 
   public:
 
+    /**
+     * @ingroup api_addr_range
+     */
     AddrRange()
         : _start(1), _end(0), intlvMatch(0)
     {}
@@ -119,6 +122,8 @@ class AddrRange
      * @param _end The end address of this range (not included in  the range)
      * @param _masks The input vector of masks
      * @param intlv_match The matching value of the xor operations
+     *
+     * @ingroup api_addr_range
      */
     AddrRange(Addr _start, Addr _end, const std::vector<Addr> &_masks,
               uint8_t _intlv_match)
@@ -154,6 +159,8 @@ class AddrRange
      * @param _xor_high_bit The MSB of the xor bit (disabled if 0)
      * @param _intlv_bits the size, in bits, of the intlv and xor bits
      * @param intlv_match The matching value of the xor operations
+     *
+     * @ingroup api_addr_range
      */
     AddrRange(Addr _start, Addr _end, uint8_t _intlv_high_bit,
               uint8_t _xor_high_bit, uint8_t _intlv_bits,
@@ -202,6 +209,8 @@ class AddrRange
      * ranges.
      *
      * @param ranges Interleaved ranges to be merged
+     *
+     * @ingroup api_addr_range
      */
     AddrRange(const std::vector<AddrRange>& ranges)
         : _start(1), _end(0), intlvMatch(0)
@@ -242,6 +251,8 @@ class AddrRange
      * Determine if the range is interleaved or not.
      *
      * @return true if interleaved
+     *
+     * @ingroup api_addr_range
      */
     bool interleaved() const { return masks.size() > 0; }
 
@@ -249,6 +260,8 @@ class AddrRange
      * Determing the interleaving granularity of the range.
      *
      * @return The size of the regions created by the interleaving bits
+     *
+     * @ingroup api_addr_range
      */
     uint64_t granularity() const
     {
@@ -269,6 +282,8 @@ class AddrRange
      * is part of.
      *
      * @return The number of stripes spanned by the interleaving bits
+     *
+     * @ingroup api_addr_range
      */
     uint32_t stripes() const { return ULL(1) << masks.size(); }
 
@@ -276,6 +291,8 @@ class AddrRange
      * Get the size of the address range. For a case where
      * interleaving is used we make the simplifying assumption that
      * the size is a divisible by the size of the interleaving slice.
+     *
+     * @ingroup api_addr_range
      */
     Addr size() const
     {
@@ -284,16 +301,22 @@ class AddrRange
 
     /**
      * Determine if the range is valid.
+     *
+     * @ingroup api_addr_range
      */
     bool valid() const { return _start <= _end; }
 
     /**
      * Get the start address of the range.
+     *
+     * @ingroup api_addr_range
      */
     Addr start() const { return _start; }
 
     /**
      * Get the end address of the range.
+     *
+     * @ingroup api_addr_range
      */
     Addr end() const { return _end; }
 
@@ -301,6 +324,8 @@ class AddrRange
      * Get a string representation of the range. This could
      * alternatively be implemented as a operator<<, but at the moment
      * that seems like overkill.
+     *
+     * @ingroup api_addr_range
      */
     std::string to_string() const
     {
@@ -329,6 +354,8 @@ class AddrRange
      *
      * @param r Range to evaluate merging with
      * @return true if the two ranges would merge
+     *
+     * @ingroup api_addr_range
      */
     bool mergesWith(const AddrRange& r) const
     {
@@ -343,6 +370,8 @@ class AddrRange
      *
      * @param r Range to intersect with
      * @return true if the intersection of the two ranges is not empty
+     *
+     * @ingroup api_addr_range
      */
     bool intersects(const AddrRange& r) const
     {
@@ -375,6 +404,8 @@ class AddrRange
      *
      * @param r Range to compare with
      * @return true if the this range is a subset of the other one
+     *
+     * @ingroup api_addr_range
      */
     bool isSubset(const AddrRange& r) const
     {
@@ -398,6 +429,8 @@ class AddrRange
      *
      * @param a Address to compare with
      * @return true if the address is in the range
+     *
+     * @ingroup api_addr_range
      */
     bool contains(const Addr& a) const
     {
@@ -441,6 +474,8 @@ class AddrRange
      *
      * @param a the input address
      * @return the new address
+     *
+     * @ingroup api_addr_range
      */
     inline Addr removeIntlvBits(Addr a) const
     {
@@ -471,6 +506,8 @@ class AddrRange
     /**
      * This method adds the interleaving bits removed by
      * removeIntlvBits.
+     *
+     * @ingroup api_addr_range
      */
     inline Addr addIntlvBits(Addr a) const
     {
@@ -516,6 +553,8 @@ class AddrRange
      *
      * @param the input address
      * @return the flat offset in the address range
+     *
+     * @ingroup api_addr_range
      */
     Addr getOffset(const Addr& a) const
     {
@@ -536,6 +575,8 @@ class AddrRange
      *
      * @param r Range to compare with
      * @return true if the start address is less than that of the other range
+     *
+     * @ingroup api_addr_range
      */
     bool operator<(const AddrRange& r) const
     {
@@ -547,6 +588,9 @@ class AddrRange
             return intlvMatch < r.intlvMatch;
     }
 
+    /**
+     * @ingroup api_addr_range
+     */
     bool operator==(const AddrRange& r) const
     {
         if (_start != r._start)    return false;
@@ -557,6 +601,9 @@ class AddrRange
         return true;
     }
 
+    /**
+     * @ingroup api_addr_range
+     */
     bool operator!=(const AddrRange& r) const
     {
         return !(*this == r);
@@ -565,17 +612,28 @@ class AddrRange
 
 /**
  * Convenience typedef for a collection of address ranges
+ *
+ * @ingroup api_addr_range
  */
 typedef std::list<AddrRange> AddrRangeList;
 
+/**
+ * @ingroup api_addr_range
+ */
 inline AddrRange
 RangeEx(Addr start, Addr end)
 { return AddrRange(start, end); }
 
+/**
+ * @ingroup api_addr_range
+ */
 inline AddrRange
 RangeIn(Addr start, Addr end)
 { return AddrRange(start, end + 1); }
 
+/**
+ * @ingroup api_addr_range
+ */
 inline AddrRange
 RangeSize(Addr start, Addr size)
 { return AddrRange(start, start + size); }

--- a/src/base/addr_range_map.hh
+++ b/src/base/addr_range_map.hh
@@ -62,8 +62,13 @@ class AddrRangeMap
     typedef std::map<AddrRange, V> RangeMap;
 
   public:
+    /**
+     * @ingroup api_addr_range_map
+     * @{
+     */
     typedef typename RangeMap::iterator iterator;
     typedef typename RangeMap::const_iterator const_iterator;
+    /** @} */ // end of api_addr_range_map
 
     /**
      * Find entry that contains the given address range
@@ -74,6 +79,9 @@ class AddrRangeMap
      *
      * @param r An input address range
      * @return An iterator that contains the input address range
+     *
+     * @ingroup api_addr_range_map
+     * @{
      */
     const_iterator
     contains(const AddrRange &r) const
@@ -85,6 +93,7 @@ class AddrRangeMap
     {
         return find(r, [r](const AddrRange r1) { return r.isSubset(r1); });
     }
+    /** @} */ // end of api_addr_range_map
 
     /**
      * Find entry that contains the given address
@@ -95,6 +104,9 @@ class AddrRangeMap
      *
      * @param r An input address
      * @return An iterator that contains the input address
+     *
+     * @ingroup api_addr_range_map
+     * @{
      */
     const_iterator
     contains(Addr r) const
@@ -106,6 +118,7 @@ class AddrRangeMap
     {
         return contains(RangeSize(r, 1));
     }
+    /** @} */ // end of api_addr_range_map
 
     /**
      * Find entry that intersects with the given address range
@@ -116,6 +129,9 @@ class AddrRangeMap
      *
      * @param r An input address
      * @return An iterator that intersects with the input address range
+     *
+     * @ingroup api_addr_range_map
+     * @{
      */
     const_iterator
     intersects(const AddrRange &r) const
@@ -127,7 +143,11 @@ class AddrRangeMap
     {
         return find(r, [r](const AddrRange r1) { return r.intersects(r1); });
     }
+    /** @} */ // end of api_addr_range_map
 
+    /**
+     * @ingroup api_addr_range_map
+     */
     iterator
     insert(const AddrRange &r, const V& d)
     {
@@ -137,6 +157,9 @@ class AddrRangeMap
         return tree.insert(std::make_pair(r, d)).first;
     }
 
+    /**
+     * @ingroup api_addr_range_map
+     */
     void
     erase(iterator p)
     {
@@ -144,6 +167,9 @@ class AddrRangeMap
         tree.erase(p);
     }
 
+    /**
+     * @ingroup api_addr_range_map
+     */
     void
     erase(iterator p, iterator q)
     {
@@ -153,6 +179,9 @@ class AddrRangeMap
         tree.erase(p,q);
     }
 
+    /**
+     * @ingroup api_addr_range_map
+     */
     void
     clear()
     {
@@ -160,36 +189,54 @@ class AddrRangeMap
         tree.erase(tree.begin(), tree.end());
     }
 
+    /**
+     * @ingroup api_addr_range_map
+     */
     const_iterator
     begin() const
     {
         return tree.begin();
     }
 
+    /**
+     * @ingroup api_addr_range_map
+     */
     iterator
     begin()
     {
         return tree.begin();
     }
 
+    /**
+     * @ingroup api_addr_range_map
+     */
     const_iterator
     end() const
     {
         return tree.end();
     }
 
+    /**
+     * @ingroup api_addr_range_map
+     */
     iterator
     end()
     {
         return tree.end();
     }
 
+    /**
+     * @ingroup api_addr_range_map
+     */
     std::size_t
     size() const
     {
         return tree.size();
     }
 
+    /**
+     * @ingroup api_addr_range_map
+     */
     bool
     empty() const
     {


### PR DESCRIPTION
| Files | Comments | Links |
|-|-|-|
| addr_range | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/32955) |
| addr_range_map | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/32956) |
| amo | will do | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33274) |
| atomicio | won't do; not being used at many places outside src/sim | |
| barrier | won't do | |
| bitfield | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/32957) |
| bitunion | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/32958) |
| bmpwriter | won't do, only used in imgwriter | |
| callback | documeted | [here](https://gem5-review.googlesource.com/c/public/gem5/+/32959) |
| channel_addr | documented; recently added, not used in the codebase | [here](https://gem5-review.googlesource.com/c/public/gem5/+/32960) |
| chunk_generator | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/32935) |
| circlebuf | won't do; only used in gem5/src/dev/serial/terminal.hh | |
| circular_queue | documeted | [here](https://gem5-review.googlesource.com/c/public/gem5/+/32962) |
| compiler | not sure how to tag | TODO |
| condcodes | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33074) |
| coroutine | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/32963) |
| cp_annotate | won't do; removed | |
| cprintf | won't do; not being used | |
| cprintf_formats | won't do; only used by cprintf.hh | |
| crc | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/32961) |
| date | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/32974) |
| debug | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33257) |
| fenv | won't do; not used outside SPARC ISA | |
| fiber | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33054) |
| flags | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33035) |
| framebuffer | won't do | |
| hostinfo | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33094) |
| imgwriter | won't do | |
| inet | documented  | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33254) |
| inifile | won't do; not used outside src/sim | |
| intfile | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33075) |
| logging | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33076) |
| match | won't do; not used outside of src/sim| |
| output | won't do; I don't think it's essential | |
| pixel | won't do; I don't think it's essential | |
| pollevent | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33114) |
| printable | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33077) |
| random | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33115) |
| refcnt | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33116) |
| remote_gdb | will do | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33256) |
| sat_counter | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33117) |
| socket | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33078) |
| statistics | will do | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33215) |
| stl_helpers | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33118) | str | will do | TODO |
| time | documented  | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33119) |
| trace | documented  | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33255) |
| trie | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33080) |
| types| will do | TODO |
| version | documented | [here](https://gem5-review.googlesource.com/c/public/gem5/+/33079) |




