### PR TITLE
Remove mem_slave_port from Sequencer

### DIFF
--- a/src/mem/ruby/system/RubyPort.cc
+++ b/src/mem/ruby/system/RubyPort.cc
@@ -94,8 +94,6 @@ RubyPort::getPort(const std::string &if_name, PortID idx)
         return memMasterPort;
     } else if (if_name == "pio_master_port") {
         return pioMasterPort;
-    } else if (if_name == "mem_slave_port") {
-        return memSlavePort;
     } else if (if_name == "pio_slave_port") {
         return pioSlavePort;
     } else if (if_name == "master") {

--- a/src/mem/ruby/system/Sequencer.py
+++ b/src/mem/ruby/system/Sequencer.py
@@ -39,7 +39,6 @@ class RubyPort(ClockedObject):
    pio_master_port = MasterPort("Ruby mem master port")
    mem_master_port = MasterPort("Ruby mem master port")
    pio_slave_port = SlavePort("Ruby pio slave port")
-   mem_slave_port = SlavePort("Ruby memory port")
 
    using_ruby_tester = Param.Bool(False, "")
    no_retry_on_stall = Param.Bool(False, "")


### PR DESCRIPTION
I just removed the mem_slave_port param from the Sequencer file and it's .cc file. 

Change-Id: I653119d435c5c01d1a3ad7222d2c838845d59922