### PR TITLE
Allow pre-commit hook to parse unicode/nonASCII characters

### DIFF
--- a/util/style/verifiers.py
+++ b/util/style/verifiers.py
@@ -46,6 +46,11 @@ import inspect
 import os
 import re
 import sys
+# Allow pre-commit hook to parse unicode/non-ASCII characters
+# by setting the python encoding to utf-8.
+# This should be removed when moving to Python3
+reload(sys)
+sys.setdefaultencoding('utf-8')
 
 from six import add_metaclass
 


### PR DESCRIPTION
Set the default encoding in python to utf-8

Change-Id: I76ff6e573b9718d3023177bbd50b37a6ee3bc514