### PR TITLE
WIP: Fixed LupIO-TMR and LupV Board 

### DIFF
--- a/src/dev/lupio/LupioTMR.py
+++ b/src/dev/lupio/LupioTMR.py
@@ -33,3 +33,5 @@ class LupioTMR(BasicPioDevice):
     cxx_header = 'dev/lupio/lupio_tmr.hh'
     pio_size = Param.Addr(0x1000, "PIO Size")
     num_threads = Param.Int("Number of threads in the system.")
+    int_type = Param.Int("Type of interrupt.")
+

--- a/src/dev/lupio/lupio_tmr.cc
+++ b/src/dev/lupio/lupio_tmr.cc
@@ -51,15 +51,9 @@ LupioTMR::LupioTMR(const Params &params) :
     nThread(params.num_threads),
     tmrEvent([this]{ lupioTMRCallback(); }, name()),
     startCycle(0)
-{
-    start = curTick(); 
-    DPRINTF(LupioTMR, "LupioTMR initalized\n");
-}
 
-void
-LupioTMR::startup()
 {
-    startCycle = curCycle();
+    DPRINTF(LupioTMR, "LupioTMR initalized\n");
 }
 
 void
@@ -85,7 +79,7 @@ LupioTMR::updateIRQ(int level)
 uint64_t
 LupioTMR::lupioTMRCurrentTime()
 {
-    return (curTick() - start) / sim_clock::as_int::ns; 
+    return curTick() / sim_clock::as_int::ns;
 }
 
 void

--- a/src/dev/lupio/lupio_tmr.cc
+++ b/src/dev/lupio/lupio_tmr.cc
@@ -50,6 +50,7 @@ LupioTMR::LupioTMR(const Params &params) :
     system(params.system),
     nThread(params.num_threads),
     tmrEvent([this]{ lupioTMRCallback(); }, name()),
+    intType(params.int_type)
 {
     DPRINTF(LupioTMR, "LupioTMR initalized\n");
 }
@@ -64,13 +65,11 @@ LupioTMR::updateIRQ(int level)
     auto tc = system->threads[0];
     // post an interrupt
     if (level) {
-        tc->getCpuPtr()->postInterrupt(tc->threadId(),
-        ExceptionCode::INT_TIMER_MACHINE, 0);
+        tc->getCpuPtr()->postInterrupt(tc->threadId(), intType, 0);
     }
     // clear the interrupt
     else {
-        tc->getCpuPtr()->clearInterrupt(tc->threadId(),
-        ExceptionCode::INT_TIMER_MACHINE, 0);
+        tc->getCpuPtr()->clearInterrupt(tc->threadId(), intType, 0);
     }
 }
 

--- a/src/dev/lupio/lupio_tmr.cc
+++ b/src/dev/lupio/lupio_tmr.cc
@@ -148,8 +148,8 @@ LupioTMR::lupioTMRWrite(uint8_t addr, uint64_t val64, int size)
             break;
 
         case LUPIO_TMR_CTRL:
-			ie = val & LUPIO_TMR_IE;
-			pd = val & LUPIO_TMR_PD;
+		    ie = val & LUPIO_TMR_IE;
+		    pd = val & LUPIO_TMR_PD;
             DPRINTF(LupioTMR, "Write LUPIO_TMR_CTRL\n");
 
             // Stop current timer if any
@@ -181,7 +181,6 @@ LupioTMR::read(PacketPtr pkt)
 
     uint64_t read_val = lupioTMRRead(pic_addr, pkt->getSize());
     DPRINTF(LupioTMR, "Packet Read: %#x\n", read_val);
-    DPRINTF(LupioTMR, "Packet Read: %d\n", read_val);
     pkt->setUintX(read_val, byteOrder);
     pkt->makeResponse();
 

--- a/src/dev/lupio/lupio_tmr.hh
+++ b/src/dev/lupio/lupio_tmr.hh
@@ -53,8 +53,6 @@ class LupioTMR : public BasicPioDevice
     EventFunctionWrapper tmrEvent;
     int intType;
 
-    Tick start = 0; 
-    Tick next = 0; 
     Tick startTime = 0;
 
     // Register map

--- a/src/dev/lupio/lupio_tmr.hh
+++ b/src/dev/lupio/lupio_tmr.hh
@@ -54,7 +54,7 @@ class LupioTMR : public BasicPioDevice
 
     Tick start = 0; 
     Tick next = 0; 
-    Cycles startCycle;
+    Tick startTime = 0;
 
     // Register map
     enum

--- a/src/dev/lupio/lupio_tmr.hh
+++ b/src/dev/lupio/lupio_tmr.hh
@@ -51,6 +51,7 @@ class LupioTMR : public BasicPioDevice
     System *system;
     int nThread;
     EventFunctionWrapper tmrEvent;
+    int intType;
 
     Tick start = 0; 
     Tick next = 0; 

--- a/src/dev/lupio/lupio_tmr.hh
+++ b/src/dev/lupio/lupio_tmr.hh
@@ -69,9 +69,6 @@ class LupioTMR : public BasicPioDevice
         LUPIO_TMR_MAX,
     };
 
-    // Internal oscillator frequency
-    uint32_t freq = 0;
-
     // Timer registers
     uint64_t reload = 0;
 

--- a/src/dev/lupio/lupio_tmr.hh
+++ b/src/dev/lupio/lupio_tmr.hh
@@ -56,9 +56,6 @@ class LupioTMR : public BasicPioDevice
     Tick next = 0; 
     Cycles startCycle;
 
-    // Start ticking
-    virtual void startup();
-
     // Register map
     enum
     {   

--- a/src/python/gem5/components/boards/lupv_board.py
+++ b/src/python/gem5/components/boards/lupv_board.py
@@ -92,7 +92,9 @@ class LupvBoard(SimpleBoard):
             raise EnvironmentError("RiscvBoard is not compatible with Ruby")
         self.workload = RiscvLinux()
 
-        excep_code = {'INT_EXT_SUPER': 9, 'INT_EXT_MACHINE': 10}
+        self._excep_code = { 'INT_SOFT_SUPER': 1, 'INT_TIMER_SUPER': 5,
+                             'INT_TIMER_MACHINE': 7, 'INT_EXT_SUPER': 9,
+                             'INT_EXT_MACHINE': 10 }
 
         # CLINT
         self.clint = Clint(pio_addr=0x2000000)
@@ -101,9 +103,8 @@ class LupvBoard(SimpleBoard):
         self.pic = Plic(pio_addr=0xc000000)
 
         # LUPIO PIC
-        # The interrupt type is INT_EXT_SUPER
         self.lupio_pic = LupioPIC(pio_addr=0x20002000,
-                                    int_type = excep_code['INT_EXT_SUPER'])
+                                    int_type = self._excep_code['INT_EXT_SUPER'])
 
         # Interrupt IDs for PIC
         int_ids = { 'TTY': 0, 'BLK': 1, 'RNG': 2}
@@ -120,7 +121,8 @@ class LupvBoard(SimpleBoard):
         self.lupio_rtc = LupioRTC(pio_addr=0x20004000)
 
         # LUPIO TMR
-        self.lupio_tmr = LupioTMR(pio_addr=0x20006000)
+        self.lupio_tmr = LupioTMR(pio_addr=0x20006000,
+                                  int_type = self._excep_code['INT_TIMER_SUPER'])
 
         # LUPIO TTY
         self.lupio_tty = LupioTTY(pio_addr=0x20007000, platform = self.lupv,
@@ -269,6 +271,7 @@ class LupvBoard(SimpleBoard):
         Creates two files in the outdir: 'device.dtb' and 'device.dts'
         :param outdir: Directory to output the files
         """
+
         state = FdtState(addr_cells=2, size_cells=2, cpu_cells=1)
         root = FdtNode("/")
         root.append(state.addrCellsProperty())
@@ -367,7 +370,7 @@ class LupvBoard(SimpleBoard):
         for i, core in enumerate(self.get_processor().get_cores()):
             phandle = state.phandle(f"cpu@{i}.int_state")
             int_extended.append(phandle)
-            int_extended.append(0x5)    #IRQ_S_TIMER
+            int_extended.append(self._excep_code['INT_TIMER_SUPER'])
         lupio_tmr_node.append(
             FdtPropertyWords("interrupts-extended", int_extended))
         lupio_tmr_node.appendCompatible(["lupio,tmr"])
@@ -388,7 +391,7 @@ class LupvBoard(SimpleBoard):
         for i, core in enumerate(self.get_processor().get_cores()):
             phandle = state.phandle(f"cpu@{i}.int_state")
             int_extended.append(phandle)
-            int_extended.append(0xB)    #IRQ_M_EXT
+            int_extended.append(self._excep_code['INT_EXT_MACHINE'])
         plic_node.append(FdtPropertyWords("interrupts-extended", int_extended))
         plic_node.append(FdtProperty("interrupt-controller"))
         plic_node.appendCompatible(["riscv,plic0"])
@@ -407,7 +410,7 @@ class LupvBoard(SimpleBoard):
         for i, core in enumerate(self.get_processor().get_cores()):
             phandle = state.phandle(f"cpu@{i}.int_state")
             int_extended.append(phandle)
-            int_extended.append(0x9)    #IRQ_S_EXT
+            int_extended.append(self._excep_code['INT_EXT_SUPER'])
         lupio_pic_node.append(
             FdtPropertyWords("interrupts-extended", int_extended))
         lupio_pic_node.append(FdtProperty("interrupt-controller"))
@@ -466,3 +469,4 @@ class LupvBoard(SimpleBoard):
         fdt.add_rootnode(root)
         fdt.writeDtsFile(os.path.join(outdir, "device.dts"))
         fdt.writeDtbFile(os.path.join(outdir, "device.dtb"))
+

--- a/src/python/gem5/components/boards/lupv_board.py
+++ b/src/python/gem5/components/boards/lupv_board.py
@@ -104,18 +104,18 @@ class LupvBoard(SimpleBoard):
 
         # LUPIO PIC
         self.lupio_pic = LupioPIC(pio_addr=0x20002000,
-                                    int_type = self._excep_code['INT_EXT_SUPER'])
+                                  int_type = self._excep_code['INT_EXT_SUPER'])
 
         # Interrupt IDs for PIC
         int_ids = { 'TTY': 0, 'BLK': 1, 'RNG': 2}
 
         #LupV Platform
         self.lupv = LupV(pic = self.lupio_pic,
-                        uart_int_id = int_ids['TTY'])
+                         uart_int_id = int_ids['TTY'])
 
         # LUPIO RNG
         self.lupio_rng = LupioRNG(pio_addr=0x20005000, platform = self.lupv,
-                                    int_id = int_ids['RNG'])
+                                  int_id = int_ids['RNG'])
 
         # LUPIO RTC
         self.lupio_rtc = LupioRTC(pio_addr=0x20004000)
@@ -126,12 +126,12 @@ class LupvBoard(SimpleBoard):
 
         # LUPIO TTY
         self.lupio_tty = LupioTTY(pio_addr=0x20007000, platform = self.lupv,
-                                    int_id = int_ids['TTY'])
+                                  int_id = int_ids['TTY'])
         self.terminal = Terminal()
 
         # LUPIO BLK
         self.lupio_blk = LupioBLK(pio_addr=0x20000000, platform = self.lupv,
-                                    int_id = int_ids['BLK'])
+                                  int_id = int_ids['BLK'])
 
         # Note: This only works with single threaded cores.
         self.pic.n_contexts = self.processor.get_num_cores()


### PR DESCRIPTION
The LupV Board was initially connected to the wrong CPU pins (TMR was using incorrect exception codes). Once the correct pins were connected, we were having issues with the LupIO-TMR that was due to some incorrect timing conversions for scheduling events. These issues are now fixed as we are using the correct exception codes and the scheduling of the timer events is occurring properly. 