### PR TITLE
SimPoints warmup

### DIFF
--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -727,12 +727,8 @@ void
 BaseCPU::scheduleSimpointsInstStop(std::vector<Counter> inst_starts)
 {
     std::string cause = "simpoint starting point found";
-    Counter last = -1;
     for (size_t i = 0; i < inst_starts.size(); ++i) {
-        if (last != inst_starts[i]) {
-            scheduleInstStop(0, inst_starts[i], cause);
-            last = inst_starts[i];
-        }
+        scheduleInstStop(0, inst_starts[i], cause);
     }
 }
 

--- a/src/cpu/base.cc
+++ b/src/cpu/base.cc
@@ -727,8 +727,12 @@ void
 BaseCPU::scheduleSimpointsInstStop(std::vector<Counter> inst_starts)
 {
     std::string cause = "simpoint starting point found";
+    Counter last = -1;
     for (size_t i = 0; i < inst_starts.size(); ++i) {
-        scheduleInstStop(0, inst_starts[i], cause);
+        if (last != inst_starts[i]) {
+            scheduleInstStop(0, inst_starts[i], cause);
+            last = inst_starts[i];
+        }
     }
 }
 

--- a/src/python/gem5/components/processors/abstract_core.py
+++ b/src/python/gem5/components/processors/abstract_core.py
@@ -126,7 +126,8 @@ class AbstractCore(SubSystem):
         """Schedule simpoint exit events for the core.
 
         This is used to raise SIMPOINT_BEGIN exit events in the gem5 standard
-        library.
+        library. Duplicate instruction counts in the inst_starts list will not
+        be scheduled.
 
         :param inst_starts: a list of SimPoints starting instructions
         :param init: if it is True, the starting instructions will be scheduled

--- a/src/python/gem5/components/processors/base_cpu_core.py
+++ b/src/python/gem5/components/processors/base_cpu_core.py
@@ -154,10 +154,11 @@ class BaseCPUCore(AbstractCore):
 
     @overrides(AbstractCore)
     def set_simpoint(self, inst_starts: List[int], init: bool) -> None:
+        schedule_insts = [*set(inst_starts)]
         if init:
-            self.core.simpoint_start_insts = inst_starts
+            self.core.simpoint_start_insts = schedule_insts
         else:
-            self.core.scheduleSimpointsInstStop(inst_starts)
+            self.core.scheduleSimpointsInstStop(schedule_insts)
 
     @overrides(AbstractCore)
     def set_inst_stop_any_thread(self, inst: int, init: bool) -> None:

--- a/src/python/gem5/components/processors/base_cpu_core.py
+++ b/src/python/gem5/components/processors/base_cpu_core.py
@@ -154,11 +154,10 @@ class BaseCPUCore(AbstractCore):
 
     @overrides(AbstractCore)
     def set_simpoint(self, inst_starts: List[int], init: bool) -> None:
-        schedule_insts = [*set(inst_starts)]
         if init:
-            self.core.simpoint_start_insts = schedule_insts
+            self.core.simpoint_start_insts = [*set(inst_starts)]
         else:
-            self.core.scheduleSimpointsInstStop(schedule_insts)
+            self.core.scheduleSimpointsInstStop([*set(inst_starts)])
 
     @overrides(AbstractCore)
     def set_inst_stop_any_thread(self, inst: int, init: bool) -> None:

--- a/src/python/gem5/components/processors/base_cpu_core.py
+++ b/src/python/gem5/components/processors/base_cpu_core.py
@@ -155,9 +155,9 @@ class BaseCPUCore(AbstractCore):
     @overrides(AbstractCore)
     def set_simpoint(self, inst_starts: List[int], init: bool) -> None:
         if init:
-            self.core.simpoint_start_insts = [*set(inst_starts)]
+            self.core.simpoint_start_insts = sorted(set(inst_starts))
         else:
-            self.core.scheduleSimpointsInstStop([*set(inst_starts)])
+            self.core.scheduleSimpointsInstStop(sorted(set(inst_starts)))
 
     @overrides(AbstractCore)
     def set_inst_stop_any_thread(self, inst: int, init: bool) -> None:

--- a/src/python/gem5/simulate/exit_event_generators.py
+++ b/src/python/gem5/simulate/exit_event_generators.py
@@ -136,6 +136,13 @@ def simpoints_save_checkpoint_generator(
     checkpoint_dir: Path,
     simpoint: SimPoint
     ):
+    """
+    A generator for taking multiple checkpoints for SimPoints. It will save the
+    checkpoints in the checkpoint_dir path with the SimPoints' index.
+    The Simulation run loop will continue after executing the behavior of the
+    generator until all the SimPoints in the simpoint_list has taken a
+    checkpoint.
+    """
     simpoint_list = simpoint.get_simpoint_start_insts()
     count = 0
     last_start = -1
@@ -143,11 +150,18 @@ def simpoints_save_checkpoint_generator(
         m5.checkpoint((checkpoint_dir / f"cpt.SimPoint{count}").as_posix())
         last_start = simpoint_list[count]
         count += 1
+        # When the next SimPoint starting instruction is the same as the last
+        # one, it will take a checkpoint for it with index+1. Because of there
+        # are cases that the warmup length is larger than multiple SimPoints
+        # starting instructions, then they might cause duplicates in the
+        # simpoint_start_ints.
         while(count < len(simpoint_list) and 
               last_start == simpoint_list[count]):
             m5.checkpoint((checkpoint_dir / f"cpt.SimPoint{count}").as_posix())
             last_start = simpoint_list[count]
             count += 1
+        # When there are remaining SimPoints in the list, let the Simulation
+        # loop continues, otherwise, exit the Simulation loop.
         if(count < len(simpoint_list)):
             yield False
         else:

--- a/src/python/gem5/simulate/exit_event_generators.py
+++ b/src/python/gem5/simulate/exit_event_generators.py
@@ -28,6 +28,7 @@ from typing import Generator, Optional
 import m5.stats
 from ..components.processors.abstract_processor import AbstractProcessor
 from ..components.processors.switchable_processor import SwitchableProcessor
+from ..utils.simpoint import SimPoint
 from m5.util import warn
 from pathlib import Path
 
@@ -130,3 +131,24 @@ def skip_generator():
     """
     while True:
         yield False
+
+def simpoints_save_checkpoint_generator(
+    checkpoint_dir: Path,
+    simpoint: SimPoint
+    ):
+    simpoint_list = simpoint.get_simpoint_start_insts()
+    count = 0
+    last_start = -1
+    while True:
+        m5.checkpoint((checkpoint_dir / f"cpt.SimPoint{count}").as_posix())
+        last_start = simpoint_list[count]
+        count += 1
+        while(count < len(simpoint_list) and 
+              last_start == simpoint_list[count]):
+            m5.checkpoint((checkpoint_dir / f"cpt.SimPoint{count}").as_posix())
+            last_start = simpoint_list[count]
+            count += 1
+        if(count < len(simpoint_list)):
+            yield False
+        else:
+            yield True

--- a/src/python/gem5/utils/simpoint.py
+++ b/src/python/gem5/utils/simpoint.py
@@ -139,16 +139,14 @@ class SimPoint:
         instruction length is the gap between the starting instruction of a
         SimPoint and the ending instruction of the last SimPoint.
         """
-        last = 0
         warmup_list = []
         for index, start_inst in enumerate(self._simpoint_start_insts):
-            warmup_inst = start_inst - warmup_interval - last
+            warmup_inst = start_inst - warmup_interval
             if warmup_inst < 0:
-                warmup_inst = start_inst - last
+                warmup_inst = start_inst
             else:
                 warmup_inst = warmup_interval
             warmup_list.append(warmup_inst)
-            last = start_inst + self._simpoint_interval
             # change the starting instruction of a SimPoint to include the
             # warmup instruction length
             self._simpoint_start_insts[index] = start_inst - warmup_inst

--- a/src/python/gem5/utils/simpoint.py
+++ b/src/python/gem5/utils/simpoint.py
@@ -94,6 +94,11 @@ class SimPoint:
             self._warmup_list = self.set_warmup_intervals(warmup_interval)
         else:
             self._warmup_list = [0] * len(self._simpoint_start_insts)
+        
+        if (0 in self._simpoint_start_insts):
+            for index in range(len(self._simpoint_start_insts)):
+                if(self._simpoint_start_insts[index]==0):
+                    self._simpoint_start_insts[index]=1
 
     def get_weights_and_simpoints_from_file(
         self,

--- a/src/python/gem5/utils/simpoint.py
+++ b/src/python/gem5/utils/simpoint.py
@@ -94,11 +94,6 @@ class SimPoint:
             self._warmup_list = self.set_warmup_intervals(warmup_interval)
         else:
             self._warmup_list = [0] * len(self._simpoint_start_insts)
-        
-        if (0 in self._simpoint_start_insts):
-            for index in range(len(self._simpoint_start_insts)):
-                if(self._simpoint_start_insts[index]==0):
-                    self._simpoint_start_insts[index]=1
 
     def get_weights_and_simpoints_from_file(
         self,


### PR DESCRIPTION
Modify the SimPoints warmup section. It now doesn't check the gap between SimPoints, instead, it checks if the length of the SimPoint start_insts is shorter than the warmup interval. If it is, then it takes the SimPoint start_insts as the warmup interval length. 
Added a simpoint_save_checkpoint_generator to take checkpoints for SimPoints. It will output checkpoint dir name as "cpt.SimPoint[index]". 